### PR TITLE
make larch_server less talky

### DIFF
--- a/bin/larch
+++ b/bin/larch
@@ -91,7 +91,7 @@ if len(__extra__)  > 0:
 if options.server_mode:
     from larch.xmlrpc_server import LarchServer
     s = LarchServer(host='localhost', port=int(options.port),
-                    local_echo=options.echo)
+                    local_echo=options.echo, quiet=options.quiet)
     s.initialize_larch()
     s.run()
     sys.exit()

--- a/bin/larch_server
+++ b/bin/larch_server
@@ -22,11 +22,14 @@ from xmlrpclib import ServerProxy
 from larch.xmlrpc_server import LarchServer
 
 def start_server(port=4966, host='localhost',
-                 local_echo=False, with_wx=True):
+                 local_echo=False, with_wx=True, quiet=False):
     "start server"
     thispath, thisfile = os.path.split(os.path.abspath(__file__))
     exe = os.path.join(thispath, 'larch')
-    return subprocess.Popen([exe, '-r', '-p', '%d' % port])
+    if quiet:
+        return subprocess.Popen([exe, '-r', '-q', '-p', '%d' % port])
+    else:
+        return subprocess.Popen([exe, '-r', '-p', '%d' % port])
 
 
 def stop_server(port=4966, host='localhost'):
@@ -67,6 +70,8 @@ parser = OptionParser(usage=usage, prog="larch_server",
 
 parser.add_option("-p", "--port", dest="port", default='4966',
                   metavar='PORT', help="port number for server")
+parser.add_option("-q", "--quiet", action="store_true", dest="quiet", default=False,
+                  help="suppress screen messages from this launcher script")
 
 (options, args) = parser.parse_args()
 
@@ -78,9 +83,9 @@ port = int(options.port)
 
 if command == 'start':
     if test_server(port=port):
-        print 'Yes: Larch server on port %d running' % port
+        if not options.quiet: print 'Yes: Larch server on port %d running' % port
     else:
-        start_server(port=port)
+        start_server(port=port, quiet=options.quiet)
         
 elif command == 'stop':
     stop_server(port=port)
@@ -89,13 +94,13 @@ elif command == 'restart':
     if test_server(port=port):
         stop_server(port=port)
     time.sleep(0.5)
-    start_server(port=port)
+    start_server(port=port, quiet=options.quiet)
 
 elif command == 'status':
     if test_server(port=port):
-        print 'Yes: Larch server on port %d running' % port
+        if not options.quiet: print 'Yes: Larch server on port %d running' % port
         sys.exit(0)
     else:
-        print 'No: Larch server on port %d not running' % port
+        if not options.quiet: print 'No: Larch server on port %d not running' % port
         sys.exit(1)
 

--- a/lib/xmlrpc_server.py
+++ b/lib/xmlrpc_server.py
@@ -24,11 +24,12 @@ except ImportError:
 
 class LarchServer(SimpleXMLRPCServer):
     def __init__(self, host='127.0.0.1', port=5465, with_wx=True,
-                 local_echo=True, **kws):
+                 local_echo=True, quiet=False, **kws):
         self.keep_alive = True
         self.port = port
         self.with_wx = HAS_WX and with_wx
         self.local_echo = local_echo
+        self.quiet = quiet
         self.out_buffer = []
         SimpleXMLRPCServer.__init__(self, (host, port),
                                     logRequests=False, allow_none=True, **kws)
@@ -84,25 +85,26 @@ class LarchServer(SimpleXMLRPCServer):
         return ret
 
     def help(self):
-        print( 'Serving Larch at port %s' % repr(self.port))
-        # print dir(self)
-        print('Registered Functions:')
-        fnames = ['ls', 'chdir', 'cwd', 'exit', 'larch', 'wx_update',  'get_data']
-        for kname in self.funcs.keys():
-            if not kname.startswith('system') and kname not in fnames:
-                fnames.append(kname)
+        if not self.quiet: 
+            print( 'Serving Larch at port %s' % repr(self.port))
+            # print dir(self)
+            print('Registered Functions:')
+            fnames = ['ls', 'chdir', 'cwd', 'exit', 'larch', 'wx_update',  'get_data']
+            for kname in self.funcs.keys():
+                if not kname.startswith('system') and kname not in fnames:
+                    fnames.append(kname)
 
-        out = ''
-        for fname in sorted(fnames):
-            if len(out) == 0:
-                out = fname
-            else:
-                out = "%s, %s" % (out, fname)
-            if len(out) > 70:
+            out = ''
+            for fname in sorted(fnames):
+                if len(out) == 0:
+                    out = fname
+                else:
+                    out = "%s, %s" % (out, fname)
+                if len(out) > 70:
+                    print("  %s" % out)
+                    out = ''
+            if len(out) >  0:
                 print("  %s" % out)
-                out = ''
-        if len(out) >  0:
-            print("  %s" % out)
 
 
     def exit(self, app=None, **kws):


### PR DESCRIPTION
I am working on having A&A launch `larch_server` at startup.

I added a `-q` flag to `larch_server` to quiet its screen messages, which don't seem appropriate when firing up A&A from the command line.

I then modified the other two files to propagate the quiet request all the way through the server's startup.

I also set the execute bit on `larch_server`.
