### PR TITLE
feffrunner

### DIFF
--- a/bin/larch_server
+++ b/bin/larch_server
@@ -18,6 +18,7 @@ import json
 
 from optparse import OptionParser
 from xmlrpclib import ServerProxy
+from distutils.spawn import find_executable
 
 from larch.xmlrpc_server import LarchServer
 
@@ -26,10 +27,12 @@ def start_server(port=4966, host='localhost',
     "start server"
     thispath, thisfile = os.path.split(os.path.abspath(__file__))
     exe = os.path.join(thispath, 'larch')
-    if quiet:
-        return subprocess.Popen([exe, '-r', '-q', '-p', '%d' % port])
-    else:
-        return subprocess.Popen([exe, '-r', '-p', '%d' % port])
+    args = [exe, '-r', '-p', '%d' % port]
+    if quiet:                   # insert -q flag
+        args[2:2] = ['-q']
+    if os.name == 'nt':         # prepend fully resolved python executable
+        args[:0] = [find_executable('python')]
+    return subprocess.Popen(args)
 
 
 def stop_server(port=4966, host='localhost'):

--- a/doc/xafs/feffpaths.rst
+++ b/doc/xafs/feffpaths.rst
@@ -15,6 +15,113 @@ this documentation, here we describe how to read the results from FEFF into
 Larch.  The main interface for this is the :func:`feffpath` function that
 reads FEFF *feffNNNN.dat* file and creates a FeffPath Group.
 
+Running Feff
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. _feff85exafs: https://github.com/xraypy/feff85exafs
+
+Larch provides a tool for running Feff as an external executable.  The
+default behavior is intended to make it easy to use the executables
+from the `feff85exafs`_ package.  However, the FeffRunner tool is
+quite flexible and can be used to run specific modules from
+`feff85exafs`_ or other versions of Feff that you might have on your
+computer.
+
+
+..  function:: feffrunner(feffinp=None, verbose=True, repo=None)
+
+    create a FeffRunner Group from a *feffNNNN.inp* file.
+
+    :param feffinp:   name (full path of) *feff.inp* file
+    :param verbose:   flag controlling screen output from Feff [True]
+    :param repo:      full path of the location of the feff85exafs repository [None]
+    :returns: a FeffRunner Group.
+
+..  function:: feffrunner.run(exe)
+
+    run Feff for FeffRunner Group.
+
+    :param exe:   the name of the Feff program to be run [run all of feff85exafs]
+    :returns: None when Feff is run successfully or an Exception when a problem in encoiuntered
+
+The simplest example of its use is
+
+.. code:: python
+
+   a = feffrunner('path/to/feff.inp')
+   a.run()
+
+The *feff.inp* file is specified when the Group is created, then
+`feff85exafs`_ is run in the same folder as the *feff.inp* file.  In
+this case, since no argument is given to the *run()* method, the
+various modules of `feff85exafs`_ are run in sequence.  This behaves
+much like the old-fashioned, monolithic Feff executables of yore.
+
+The `feff85exafs`_ modules (*rdinp*, *pot*, *xsph*, *pathfinder*,
+*genfmt*, and *ff2x*) can be be run individually
+
+.. code:: python
+
+   a = feffrunner('path/to/feff.inp')
+   a.run('rdinp')
+   a.run('pot')
+   ## and so on ...
+
+To specifically use the `feff85exafs`_ modules from a local copy of
+the feff85exafs repository, do
+
+.. code:: python
+
+   a = feffrunner('path/to/feff.inp')
+   a.repo = '/home/bruce/git/feff85exafs'
+   a.run()
+
+The ``repo`` attribute is used when working on `feff85exafs`_ itself.
+For example, the `feff85exafs`_ unit tests set the ``repo`` attribute
+so that the just-compiled versions of the programs get used.
+
+If you have an executable for some other version of Feff in a location
+that in your shell's execution path and it is called something like
+*feff6*, *feff7*, or any other name than begins with *feff*, that can
+be run as
+
+.. code:: python
+
+   a = feffrunner('path/to/feff.inp')
+   a.run('feff6') # or whatever your executable is called
+
+If the *_xafs._feff_executable* symbol in Larch's symbol table is set
+to a valid executable, then you can use that by doing
+
+.. code:: python
+
+   a = feffrunner('path/to/feff.inp')
+   a.run(None)
+
+The *feff.inp* file need not be called by that name.  FeffRunner will
+copy the specified file to *feff.inp* in the specified folder --
+taking care **not** to clobber an existing *feff.inp* file -- before
+running Feff.  Once finished, it will copy files back to their
+original names.
+
+A log file called *f85e.log* is written in the same folder as the
+*feff.inp*.  This log file captures all of the screen output (both
+STDOUT and STDERR) from Feff.
+
+The full structure of the FeffRunner group looks something like this::
+
+    == External Feff Group: Copper/testrun/feff.inp: 5 symbols ==
+      feffinp: 'Copper/testrun/feff.inp'
+      repo: None
+      resolved: '/usr/local/bin/ff2x'
+      run: <bound method FeffRunner.run of <External Feff Group: Copper/testrun/feff.inp>>
+      verbose: True
+
+The ``resolved`` attribute has the fully resolved path to the most
+recently run executable.  This can be used to verify that the
+logic for executable resolution described above worked as intended.
+
+
 
 :func:`feffpath` and FeffPath Groups
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/plugins/std/show.py
+++ b/plugins/std/show.py
@@ -6,7 +6,6 @@ import sys
 import types
 import numpy
 from larch import Group, ValidateLarchPlugin
-from termcolor import colored
 
 @ValidateLarchPlugin
 def _get(sym=None, _larch=None, **kws):
@@ -64,8 +63,6 @@ def _show(sym=None, _larch=None, with_private=False, **kws):
         title = 'Group _main'
 
     members = dir(group)
-    colors=('white', 'cyan')
-    count=1
     out = ['== %s: %i symbols ==' % (title, len(members))]
     for item in members:
         if (item.startswith('__') and item.endswith('__') and
@@ -77,15 +74,9 @@ def _show(sym=None, _larch=None, with_private=False, **kws):
             if len(obj) > 10 or len(obj.shape)>1:
                 dval = "array<shape=%s, type=%s>" % (repr(obj.shape),
                                                          repr(obj.dtype))
-        elif isinstance(obj, (list, tuple)):
-            if len(obj) > 6:
-                dval = "%s, %d items, [%s, ..., %s]" % (type(obj).__name__, len(obj), str(obj[0]), str(obj[-1]))
         if dval is None:
             dval = repr(obj)
-        #out.append(colored('  %s: ' % item, 'yellow', attrs=['bold']) +
-        #           colored('%s' % dval, colors[count%2]) )
         out.append('  %s: %s' % (item, dval))
-        count+=1
 #         if not (item.startswith('_Group__') or
 #                 item == '__name__' or item == '_larch' or
 #                 item.startswith('_SymbolTable__')):

--- a/plugins/std/show.py
+++ b/plugins/std/show.py
@@ -6,6 +6,7 @@ import sys
 import types
 import numpy
 from larch import Group, ValidateLarchPlugin
+from termcolor import colored
 
 @ValidateLarchPlugin
 def _get(sym=None, _larch=None, **kws):
@@ -63,6 +64,8 @@ def _show(sym=None, _larch=None, with_private=False, **kws):
         title = 'Group _main'
 
     members = dir(group)
+    colors=('white', 'cyan')
+    count=1
     out = ['== %s: %i symbols ==' % (title, len(members))]
     for item in members:
         if (item.startswith('__') and item.endswith('__') and
@@ -74,9 +77,15 @@ def _show(sym=None, _larch=None, with_private=False, **kws):
             if len(obj) > 10 or len(obj.shape)>1:
                 dval = "array<shape=%s, type=%s>" % (repr(obj.shape),
                                                          repr(obj.dtype))
+        elif isinstance(obj, (list, tuple)):
+            if len(obj) > 6:
+                dval = "%s, %d items, [%s, ..., %s]" % (type(obj).__name__, len(obj), str(obj[0]), str(obj[-1]))
         if dval is None:
             dval = repr(obj)
+        #out.append(colored('  %s: ' % item, 'yellow', attrs=['bold']) +
+        #           colored('%s' % dval, colors[count%2]) )
         out.append('  %s: %s' % (item, dval))
+        count+=1
 #         if not (item.startswith('_Group__') or
 #                 item == '__name__' or item == '_larch' or
 #                 item.startswith('_SymbolTable__')):

--- a/plugins/xafs/feffrunner.py
+++ b/plugins/xafs/feffrunner.py
@@ -1,0 +1,209 @@
+
+import os
+from   os.path   import realpath, isdir, isfile, join, basename, dirname
+from   distutils.spawn import find_executable
+from shutil import copy, move
+import subprocess
+
+from larch import (Group, Parameter, isParameter, param_value, use_plugin_path, isNamedClass, Interpreter)
+use_plugin_path('std')
+from show import _show
+
+class FeffRunner(Group):
+    """A Larch plugin for managing calls to the feff85exafs stand-alone executables.
+    This plugin does not manage the output of Feff.  See feffpath() and other tools.
+
+    Methods:
+        run -- run one or more parts of feff
+
+            a = feffrunner(feffinp='path/to/feff.inp')
+            a.run() to run feff monolithically
+            a.run(exe='rdinp')
+            a.run(exe='xsph')
+               and so on to run individual parts of feff
+               ('rdinp', 'pot', 'xsph', 'pathfinder', 'genfmt', 'ff2x')
+
+          By default, installed versions of the feff executables are
+          run.  To run newly compiled versions from the feff85exafs
+          git repository, set the repo attribute to the top of the
+          respository:
+
+            a = feffrunner(feffinp='path/to/feff.inp')
+            a.repo = '/home/bruce/git/feff85exafs'
+            a.run()
+
+          run returns None if feff ran successfully, otherwise it
+          returns an Exception with a useful message
+
+          Other versions of feff can also be handled, with the caveat
+          that the executable begins with "feff', i.e. "feff6",
+          "feff7", etc.
+
+            a = feffrunner(feffinp='path/to/feff6.inp')
+            a.run(module='feff6')
+
+          If the value of the feffinp attribute is a file with a
+          basename other than "feff.inp", that file will be renamed to
+          "feff.inp" and care will be taken to preserve and existing
+          file by that name.
+
+    Attributes:
+        feffinp  -- the feff.inp file, absolute or relative to CWD
+        repo     -- when set to the top of the feff85exfas repository, the newly compiled executables will be used
+        resolved -- the fully resolved path to the most recently run executable
+        verbose  -- write screen messages if True
+    """
+
+    def __init__(self, feffinp=None, verbose=True, repo=None, _larch=None, **kws):
+        kwargs = dict(name='Feff runner')
+        kwargs.update(kws)
+        Group.__init__(self,  **kwargs)
+        if _larch == None:
+            self._larch   = Interpreter()
+        else:
+            self._larch = _larch
+        self.feffinp  = feffinp
+        self.verbose  = verbose
+        self.repo     = repo
+        self.resolved = None
+
+
+    def __repr__(self):
+        if self.feffinp is not None:
+            if not isfile(self.feffinp):
+                return '<External Feff Group (empty)>'
+            return '<External Feff Group: %s>' % self.feffinp
+        return '<External Feff Group (empty)>'
+
+
+    def run(self, exe='monolithic'):
+        """Make system call to run one or more of the stand-alone executables,
+        writing a log file to the folder containing the input file.
+
+        """
+
+        if self.feffinp == None:
+            raise Exception("no feff.inp file was specified")
+        if not isfile(self.feffinp):
+            raise Exception("feff.inp file '%s' could not be found" % self.feffinp)
+
+        savefile = '.save_save_save.inp'
+        here=os.getcwd()
+        os.chdir(dirname(self.feffinp))
+        log = 'f85e.log'
+        
+        if exe == None:
+            exe = ''
+        else:
+            if not ((exe in ('monolithic', 'rdinp', 'pot', 'xsph', 'pathfinder', 'genfmt', 'ff2x')) or exe.startswith('feff')):
+                os.chdir(here)
+                raise Exception("'%s' is not a valid executable name" % exe)
+
+        ## default behavior is to step through the feff85exafs modules
+        if exe.startswith('mono'): # run modules recursively
+            if isfile(log): os.unlink(log)
+            for m in ('rdinp', 'pot', 'xsph', 'pathfinder', 'genfmt', 'ff2x'):
+                os.chdir(here)
+                self.run(m)
+            return
+        elif exe.startswith('feff'):
+            if isfile(log): os.unlink(log)
+
+        ## if exe is unset or not set to something already recognized,
+        ## try to figure out what executable to run
+        ##
+        ## the logic is:
+        ##  1. if exe seems to be a feff version, try to find that Feff executable
+        ##  2. if repo is None, try to find the installed executable
+        ##  3. if repo is set, try to find the newly compiled executable
+        ##  4. if nothing has been found, try to use _xafs.feff_executable
+        ##  5. if nothing is found, raise and Exception
+        program=None
+        if exe.startswith('feff'): # step 1, exe seems to be numbered feff (e.g. feff6, feff7, ...)
+            self.resolved = find_executable(exe)
+            if self.resolved:
+                program=self.resolved
+
+        if exe in ('rdinp', 'pot', 'xsph', 'pathfinder', 'genfmt', 'ff2x'):
+            if self.repo == None: # step 2, try to find the installed feff85exafs module
+                self.resolved = find_executable(exe)
+                if not os.access(self.resolved, os.X_OK):
+                    os.chdir(here)
+                    raise Exception("'%s' is not an executable" % self.resolved)
+                if self.resolved:
+                    program=self.resolved
+            else:                   # step 3, try to find the newly compiled feff85exafs module
+                folder=exe.upper()
+                if exe=='pathfinder':
+                    folder='PATH'
+                program=join(self.repo, 'src', folder, exe)
+                self.resolved=program
+                if not isfile(program):
+                    os.chdir(here)
+                    raise Exception("'%s' cannot be found (has it been compiled?)" % program)
+                if not os.access(program, os.X_OK):
+                    os.chdir(here)
+                    raise Exception("'%s' is not an executable" % program)
+
+        if program == None:  # step 4, try _xafs.feff_executable
+            program = self._larch.symtable.get_symbol('_xafs._feff_executable')[0]
+            try:
+                program = self._larch.symtable.get_symbol('_xafs._feff_executable')[0]
+            except NameError:
+                print program
+                os.chdir(here)
+                raise Exception("_xafs._feff_executable is not set (1)")
+            except AttributeError:
+                print program
+                os.chdir(here)
+                raise Exception("_xafs._feff_executable is not set (2)")
+
+        if program != None:
+            if not os.access(program, os.X_OK):
+                program = None
+
+        if program == None:  # step 5, give up
+            os.chdir(here)
+            raise Exception("'%s' executable cannot be found" % exe)
+
+        ## preserve an existing feff.inp file if this is not called feff.inp
+        if basename(self.feffinp) != 'feff.inp':
+            if isfile('feff.inp'):
+                copy('feff.inp', savefile)
+                copy(basename(self.feffinp), 'feff.inp')
+
+        f = open(log, 'a')
+        header = "\n======= running module %s ====================================================\n" % exe
+        if self.verbose: print header
+        f.write(header)
+        process=subprocess.Popen(program, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+        while True:
+            line = process.stdout.readline()
+            if not line:
+                break
+            if self.verbose: print ':'+line.rstrip()
+            f.write(line)
+        f.close
+
+        if isfile(savefile):
+            move(savefile, 'feff.inp')
+        os.chdir(here)
+        return None
+
+######################################################################
+
+def initializeLarchPlugin(_larch=None):
+    """initialize _xafs._feff_executable"""
+    _larch.symtable.set_symbol('_xafs._feff_executable', ['/usr/local/bin/feff6',])
+
+
+def feffrunner(feffinp=None, verbose=True, repo=None, _larch=None, **kws):
+    """
+    Make a FeffRunner group given a folder containing a baseline calculation
+    """
+    return FeffRunner(feffinp=feffinp, verbose=verbose, repo=repo, _larch=_larch)
+    
+    
+def registerLarchPlugin(): # must have a function with this name!
+    return ('_xafs', { 'feffrunner': feffrunner })
+    

--- a/plugins/xrfmap/xsp3_hdf5.py
+++ b/plugins/xrfmap/xsp3_hdf5.py
@@ -41,9 +41,9 @@ class XSP3Data(object):
         self.inputCounts  = np.zeros((npix, ndet), dtype='f8')
         # self.counts       = np.zeros((npix, ndet, nchan), dtype='f4')
 
-#  @ValidateLarchPlugin
+@ValidateLarchPlugin
 def read_xsp3_hdf5(fname, npixels=None, verbose=False,
-                   kludge_dtc=True, _larch=None):
+                   kludge_dtc=False, _larch=None):
     # Reads a HDF5 file created with the DXP xMAP driver
     # with the netCDF plugin buffers
     npixels = None
@@ -74,9 +74,8 @@ def read_xsp3_hdf5(fname, npixels=None, verbose=False,
 
     if kludge_dtc:
         dtc_taus = XSPRESS3_TAUS
-        if _larch is not None:
-            if _larch.symtable.has_symbol('_sys.gsecars.xspress3_taus'):
-                dtc_taus = _larch.symtable._sys.gsecars.xspress3_taus
+        if _larch.symtable.has_symbol('_sys.gsecars.xspress3_taus'):
+            dtc_taus = _larch.symtable._sys.gsecars.xspress3_taus
         
     for i in range(ndet):
         rtime = (ndattr['CHAN%iSCA0' % (i+1)].value * clocktick).astype('i8')


### PR DESCRIPTION
Here is my xafs plugin for running feff externally.  It works to my satisfaction both in the unit tests for feff85exafs and in the tests on the effect of SCF on the EXAFS fitting.

I have also added documentation to this PR.

As you suggested, I changed the name to "feffrunner" and did the right thing with `_larch`.  I did not quite follow your suggestion for how to specify the executable, although I made it possible to specify an executable in the `_xafs._feff_executable` symbol (although I think I found a bug related to that, which I will submit as an issue shortly) by doing
```python
a=feffrunner('path/to/feff.inp')
a.run(None)
```
as opposed to this:
```python
a=feffrunner('path/to/feff.inp')
a.run()
```
which defaults to trying to run the feff85exafs executables in sequence, which is my current preference for the default behavior.