### PR TITLE
Enable plugins

### DIFF
--- a/examples/programming/Py_usinglarch.py
+++ b/examples/programming/Py_usinglarch.py
@@ -1,14 +1,12 @@
 import numpy as np
 import pylab
+from larch import enable_plugins, Interpreter, Group
 
-from larch import use_plugin_path, Interpreter, Group
-
-# tell Python to where to find larch plugins
-use_plugin_path('xafs')
+# tell Python to use all larch plugins
+enable_plugins()
+# now import larch-specific Python code
 from autobk import autobk
-from xafsft import xftf 
-
-use_plugin_path('math')
+from xafsft import xftf
 from mathutils import index_nearest # (uses numpy's argmin())
 
 # create a larch interpreter, passed to most functions
@@ -30,7 +28,7 @@ xafsdat.i0     = rawdata[:, 1]
 # write data for 'k', 'chi', 'kwin', 'e0', ... into xafsdat
 autobk(xafsdat, rbkg=1.0, kweight=2, _larch=my_larch)
 
-# Fourier transform to R space, again passing in a Group (here, 
+# Fourier transform to R space, again passing in a Group (here,
 # 'k' and 'chi' are expected, and writitng out 'r', 'chir_mag',
 # and so on
 xftf(xafsdat, kmin=2, kmax=15, dk=3, kweight=2, _larch=my_larch)
@@ -66,4 +64,3 @@ pylab.xlabel(r'$ R (\AA) $')
 pylab.ylabel(r'$ \chi(R) (\AA^{-3}) $')
 
 pylab.show()
-

--- a/examples/programming/autobk.py
+++ b/examples/programming/autobk.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+## Autobk (XAFS background subtraction) in pure Python,
+## using Python code from Larch.
+from larch import Interpreter, enable_plugins
+enable_plugins()
+
+from pre_edge import pre_edge
+from autobk import autobk
+from columnfile import _read_ascii
+
+_larch = Interpreter()
+
+fname = '../xafsdata/cu_rt01.xmu'
+
+cu = _read_ascii(fname, labels='energy mu i0', _larch=_larch)
+print 'Read ASCII File:', cu
+print dir(cu)
+
+pre_edge(cu, _larch=_larch)
+print 'After pre-edge:'
+print dir(cu)
+
+autobk(cu, rbkg=1.0, kweight=1, _larch=_larch)
+
+print 'After autobk:'
+print dir(cu)

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -13,7 +13,8 @@ major, minor = sys.version_info[0], sys.version_info[1]
 if major < 2 or (major == 2 and minor < 6):
     raise EnvironmentError('requires python 2.6 or higher')
 
-from .larchlib import plugin_path, use_plugin_path, isNamedClass, LarchPluginException
+from .larchlib import (plugin_path, use_plugin_path, enable_plugins,
+                       isNamedClass, LarchPluginException)
 from .site_config import show_site_config
 from .symboltable import Group, SymbolTable, isgroup
 from .fitting import Minimizer, Parameter, isParameter, param_value

--- a/lib/larchlib.py
+++ b/lib/larchlib.py
@@ -378,6 +378,15 @@ def use_plugin_path(val):
     """
     sys.path.insert(0, plugin_path(val))
 
+def enable_plugins():
+    """add all available Larch plugin paths
+    """
+    plugin_dir = os.path.abspath(os.path.join(larchdir, 'plugins'))
+    for name in reversed(os.listdir(plugin_dir)):
+        dname = os.path.abspath(os.path.join(plugin_dir, name))
+        if os.path.isdir(dname):
+            sys.path.insert(0, dname)
+
 def add2path(envvar='PATH', dirname='.'):
     """add specified dir to begninng of PATH and
     DYLD_LIBRARY_PATH, LD_LIBRARY_PATH environmental variables,


### PR DESCRIPTION
add ``larch.enable_plugins()`` to dynamically add all plugin paths to ``sys.path``, thereby allowing any larch plugin to be imported from Python.  