### PR TITLE
Better plugins import

### DIFF
--- a/bin/DTCorrect_ESCAN
+++ b/bin/DTCorrect_ESCAN
@@ -1,11 +1,7 @@
 #!/usr/bin/env python
 """
-GSECARS ESCAN Deadtime Correction App 
+GSECARS ESCAN Deadtime Correction App
 """
 import larch
-larch.use_plugin_path('wx')
-
-from gse_dtcorrect import DTViewer
-
+from larch_plugins.wx import DTViewer
 DTViewer().MainLoop()
-

--- a/bin/EpicsXRFDisplay
+++ b/bin/EpicsXRFDisplay
@@ -4,6 +4,6 @@ GSECARS Epics XRF Display App
 """
 import os
 import larch
-from larch_plugins.wx import EpicsXRFApp
+from larch_plugins.epics import EpicsXRFApp
 os.chdir(larch.site_config.home_dir)
 EpicsXRFApp().MainLoop()

--- a/bin/EpicsXRFDisplay
+++ b/bin/EpicsXRFDisplay
@@ -1,15 +1,9 @@
 #!/usr/bin/env python
 """
-GSECARS Epics XRF Display App 
+GSECARS Epics XRF Display App
 """
-import os, sys
+import os
 import larch
-
-larch.use_plugin_path('epics')
-
-from xrfcontrol import EpicsXRFApp
-
+from larch_plugins.wx import EpicsXRFApp
 os.chdir(larch.site_config.home_dir)
-
 EpicsXRFApp().MainLoop()
-

--- a/bin/GSE_MapViewer
+++ b/bin/GSE_MapViewer
@@ -5,9 +5,7 @@ Viewer App for GSE XRF Maps
 import os
 import sys
 import larch
-larch.use_plugin_path('wx')
-
-from mapviewer import MapViewer
+from larch_plugins.wx import MapViewer
 
 os.chdir(larch.site_config.home_dir)
 MapViewer().run()

--- a/bin/ScanViewer
+++ b/bin/ScanViewer
@@ -3,11 +3,8 @@
 Viewer App for ASCII Column Data
 """
 import os
-import sys
 import larch
-larch.use_plugin_path('wx')
-
-from scanviewer import ScanViewer
+from larch_plugins.wx import ScanViewer
 
 os.chdir(larch.site_config.home_dir)
 ScanViewer().run()

--- a/bin/XRF_Display
+++ b/bin/XRF_Display
@@ -1,11 +1,8 @@
 #!/usr/bin/env python
 """
-GSECARS XRF Display App 
+GSECARS XRF Display App
 """
 import larch
-larch.use_plugin_path('wx')
-
-from xrfdisplay import XRFApp
+from larch_plugins.wx import XRFApp
 
 XRFApp().MainLoop()
-

--- a/doc/devel/frompython.rst
+++ b/doc/devel/frompython.rst
@@ -35,7 +35,7 @@ Thus to get the :func:`_xafs.autobk` function into a Python module, you
 could do either::
 
     import larch
-    from larch_plugins.xafs.autobk import autobk
+    from larch_plugins.xafs import autobk
 
 or::
 
@@ -47,19 +47,21 @@ The first approach is encouraged, the latter kept for backward compatibility.
 
 The second consideration is that many of the functions in the Larch plugins
 will only work if they are passed an instance of the Larch interpreter.
-This is primarily used inside Larch plugins to create Groups, or to access
-data from the builtin ``_sys`` module, which requires a namespace and
-working interpreter.  Though you won't need to write Larch scripts inside
+This interpreter instance is primarily used inside Larch plugins to create
+Groups and place them in the current symbol table, or to access
+data from the builtin ``_sys`` module  or from data resouces loaded into
+the ``_xray`` module.
+Though you won't need to write Larch scripts inside
 python (you **can**, but if you're reading this section, you probably want
 to use Python instead of Larch), you will need an instance of the
 interpreter.  This is easily created, and can then be passed to any of the
 plugin functions with the ``_larch`` keyword argument::
 
     from larch import Interpreter
-    from larch_plugins.xafs.autobk import autobk
-    from larch_plugins.io.xdi import read_xdi
+    from larch_plugins.xafs import autobk
+    from larch_plugins.io import read_xdi
 
-    mylarch = Interpreter()
+    mylarch = Interpreter(with_plugins=False)
     dat = read_xdi('../xafsdata/fe3c_rt.xdi', _larch=mylarch)
     dat.mu = dat.mutrans
     autobk(dat, rbkg=1.0, kweight=2, _larch=mylarch)
@@ -67,3 +69,26 @@ plugin functions with the ``_larch`` keyword argument::
 That is, the ``_larch=mylarch`` argument is vital to having
 :func:`_io.read_xdi` properly create a Larch group, and for allowing
 :func:`_xafs.autobk` to do the actual fit, and organize the results.
+
+
+Note that you can create the interpreter without loading all the plugins
+using ``with_plugins=False``.  When running from python, this may be a
+reasonable default.  If you want to add some of the plugins for a
+particular interpreter session, you can::
+
+    >>> import larch
+    >>> session = larch.Interpreter(with_plugins=False)
+    >>> session.add_plugin('xray')
+    >>> session.run("cu_ka = xray_line('Cu', 'Ka1')")
+    >>> session.symtable.cu_ka
+    (8046.3, 0.577108, u'K', u'L3')
+
+This would be nearly the same as doing::
+
+    >>> import larch
+    >>> from larch_plugins.xray import xray_line
+    >>> session = larch.Interpreter(with_plugins=False)
+    >>> xray_line('Cu', 'Ka1', _larch=session)
+    (8046.3, 0.577108, u'K', u'L3')
+
+except that the former Larch session retains the value in ``cu_ka``.

--- a/examples/programming/Py_usinglarch.py
+++ b/examples/programming/Py_usinglarch.py
@@ -3,12 +3,11 @@ import pylab
 from larch import Interpreter, Group
 
 # now import larch-specific Python code
-from larch_plugins.xafs.autobk import autobk
-from larch_plugins.xafs.xafsft import xftf
-from larch_plugins.math.mathutils import index_nearest # (uses numpy's argmin())
+from larch_plugins.xafs import autobk, xftf
+from larch_plugins.math import index_nearest # (uses numpy's argmin())
 
 # create a larch interpreter, passed to most functions
-my_larch = Interpreter()
+my_larch = Interpreter(with_plugins=False)
 
 # create an empty Group
 xafsdat = Group()

--- a/examples/programming/autobk.py
+++ b/examples/programming/autobk.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python
 
 ## Autobk (XAFS background subtraction) in pure Python,
-## using Python code from Larch.
+## using Python code from Lxsarch.
 from larch import Interpreter
 
-from larch_plugins.xafs.pre_edge import pre_edge
-from larch_plugins.xafs.autobk import autobk
-from larch_plugins.io.columnfile import _read_ascii
+from larch_plugins.xafs import pre_edge, autobk
+from larch_plugins.io import read_ascii
 
-_larch = Interpreter()
+# create plain interpreter, don't load all the plugins
+_larch = Interpreter(with_plugins=False)
 
 fname = '../xafsdata/cu_rt01.xmu'
 
-cu = _read_ascii(fname, labels='energy mu i0', _larch=_larch)
+cu = read_ascii(fname, labels='energy mu i0', _larch=_larch)
 print 'Read ASCII File:', cu
 print dir(cu)
 

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -24,8 +24,6 @@ from .inputText import InputText
 from .utils import Closure, fixName
 from .version import __date__, __version__
 
-enable_plugins()
-
 def ValidateLarchPlugin(fcn):
     """function decorator to ensure that _larch is included in keywords,
     and that it is a valid Interpeter"""
@@ -44,3 +42,5 @@ def ValidateLarchPlugin(fcn):
     wrapper.__filename__ = fcn.__code__.co_filename
     wrapper.__dict__.update(fcn.__dict__)
     return wrapper
+
+enable_plugins()

--- a/lib/builtins.py
+++ b/lib/builtins.py
@@ -281,9 +281,9 @@ def _addplugin(plugin, _larch=None, **kws):
     if _larch is None:
         raise Warning("cannot add plugins. larch broken?")
     write = _larch.writer.write
-    errmsg = 'is not a valid larch plugin\n'
+    errmsg = 'is (not!) a valid larch plugin\n'
     pjoin = os.path.join
-
+    # print("ADD PLUGIN ", plugin)
     path = site_config.plugins_path
     _sysconf = _larch.symtable._sys.config
     if not hasattr(_sysconf, 'plugin_paths'):
@@ -295,6 +295,9 @@ def _addplugin(plugin, _larch=None, **kws):
                 False, (fh, modpath, desc) for imported modules
                 None, None for Not Found
         """
+
+        if plugin == '__init__':
+            return None, None
         mod, is_pkg = None, False
         try:
             mod = imp.find_module(plugin, [p_path])
@@ -357,6 +360,7 @@ def _addplugin(plugin, _larch=None, **kws):
                 path = site_config.plugins_path
 
         for p_path in path:
+            # print(" -- find_plugin ", plugin)
             is_pkg, mod = _find_plugin(plugin, p_path)
             if is_pkg is not None:
                 break
@@ -390,7 +394,9 @@ def _addplugin(plugin, _larch=None, **kws):
                     try:
                         ret =  _plugin_file(fname[:-3], path=[mod])
                     except:
-                        write('Warning: %s is not a valid plugin\n' %
+                        err, exc, tback = sys.exc_info()
+                        write(traceback.print_tb(tback))
+                        write('Warning: %s is =not= a valid plugin\n' %
                               pjoin(mod, fname))
                         write("   error:  %s\n" % (repr(sys.exc_info()[1])))
 

--- a/lib/builtins.py
+++ b/lib/builtins.py
@@ -6,6 +6,7 @@ import imp
 import sys
 import time
 import re
+import traceback
 
 from .helper import Helper
 from . import inputText
@@ -185,9 +186,6 @@ def _eval(text=None, filename=None, _larch=None,
         b = block.strip()
         if len(b) <= 0:
             continue
-        # print 'eval %i  : %i, %s ' % (lineno, len(block), block)
-
-
         ret = _larch.eval(block, fname=fname, lineno=lineno)
         if hasattr(ret, '__call__') and not isinstance(ret, type):
             try:
@@ -303,7 +301,6 @@ def _addplugin(plugin, _larch=None, **kws):
         except ImportError:
             is_pkg = os.path.isdir(pjoin(p_path, plugin))
 
-        # write("LARCH ADD_PLUGIN FIND PLUGIN ", plugin, p_path, is_pkg, mod)
         if is_pkg or (mod is not None and
                       mod[2][2] == imp.PKG_DIRECTORY):
             return True, pjoin(p_path, plugin)
@@ -351,7 +348,8 @@ def _addplugin(plugin, _larch=None, **kws):
     def _plugin_file(plugin, path=None):
         "defined here to allow recursive imports for packages"
         fh = None
-
+        if plugin == '__init__':
+            return
         if path is None:
             try:
                 path = _larch.symtable._sys.config.plugins_path
@@ -410,8 +408,8 @@ def _addplugin(plugin, _larch=None, **kws):
                 offset = getattr(exc, 'offset', 0)
                 etext  = getattr(exc, 'text', '')
                 emsg   = getattr(exc, 'message', '')
-                # write(traceback.print_tb(tback))
-                write("""Python Error in plugin '%s', line %d
+                write(traceback.print_tb(tback))
+                write("""Python Error at plugin '%s', line %d
   %s %s^
 %s: %s\n""" % (modpath, lineno, etext, ' '*offset, err.__name__, emsg))
                 retval = False

--- a/lib/interpreter.py
+++ b/lib/interpreter.py
@@ -89,7 +89,7 @@ class Interpreter:
                        'subscript', 'tryexcept', 'tuple', 'unaryop',
                        'while')
 
-    def __init__(self, symtable=None, writer=None):
+    def __init__(self, symtable=None, writer=None, with_plugins=True):
         self.writer = writer or sys.stdout
 
         if symtable is None:
@@ -134,12 +134,12 @@ class Interpreter:
         for cmd in builtins.valid_commands:
             self.symtable._sys.valid_commands.append(cmd)
 
-        # add all plugins in standard plugins folder
-        plugins_dir = os.path.join(site_config.larchdir, 'plugins')
-        for pname in os.listdir(plugins_dir):
-            pdir = os.path.join(plugins_dir, pname)
-            if os.path.isdir(pdir):
-                builtins._addplugin(pdir, _larch=self)
+        if with_plugins: # add all plugins in standard plugins folder
+            plugins_dir = os.path.join(site_config.larchdir, 'plugins')
+            for pname in os.listdir(plugins_dir):
+                pdir = os.path.join(plugins_dir, pname)
+                if os.path.isdir(pdir):
+                    builtins._addplugin(pdir, _larch=self)
 
         self.node_handlers = dict(((node, getattr(self, "on_%s" % node))
                                    for node in self.supported_nodes))

--- a/lib/larchlib.py
+++ b/lib/larchlib.py
@@ -384,7 +384,7 @@ def enable_plugins():
     topdir = os.path.abspath(larchdir)
     sys.path.insert(0, topdir)
     import plugins
-    sys.modules['larch.plugins'] = plugins
+    sys.modules['larch_plugins'] = plugins
     return plugins
 
 def add2path(envvar='PATH', dirname='.'):

--- a/plugins/epics/__init__.py
+++ b/plugins/epics/__init__.py
@@ -1,5 +1,6 @@
-# from .epics_plugin import PV, caget, caput
+from .epics_plugin import PV, caget, caput
 # from .xrf_detectors import Epics_MultiXMAP, Epics_Xspress3
 # from .detectors import get_detector, Counter
 # from .positioner import  Positioner
 # from .stepscan import LarchStepScan
+from .xrfcontrol import EpicsXRFApp

--- a/plugins/epics/__init__.py
+++ b/plugins/epics/__init__.py
@@ -1,0 +1,2 @@
+from .epics_plugin import PV, caget, caput
+from .xrf_detectors import Epics_MultiXMAP, Epics_Xspress3

--- a/plugins/epics/__init__.py
+++ b/plugins/epics/__init__.py
@@ -1,2 +1,5 @@
-from .epics_plugin import PV, caget, caput
-from .xrf_detectors import Epics_MultiXMAP, Epics_Xspress3
+# from .epics_plugin import PV, caget, caput
+# from .xrf_detectors import Epics_MultiXMAP, Epics_Xspress3
+# from .detectors import get_detector, Counter
+# from .positioner import  Positioner
+# from .stepscan import LarchStepScan

--- a/plugins/epics/epics_plugin.py
+++ b/plugins/epics/epics_plugin.py
@@ -50,8 +50,8 @@ caget_doc = """caget(pvname, as_string=False, use_numpy=True, timeout=None)
     Notes
     ------
       1. The default timeout is 0.5 sec for scalar PVs.
-      
-""" 
+
+"""
 
 caput_doc = """caput(pvname, value, wait=False, timeout=60)
 
@@ -78,7 +78,7 @@ caput_doc = """caput(pvname, value, wait=False, timeout=60)
     -----
      1.  waiting may take a long time, as it waits for all processing
          to complete (motor move, detector acquire to finish, etc).
-""" 
+"""
 
 cainfo_doc = """cainfo(pvname, print_out=True)
 
@@ -93,7 +93,7 @@ cainfo_doc = """cainfo(pvname, print_out=True)
     Returns
     -------
        None or string with info paragraph
-       
+
     Examples
     --------
       cainfo('xx.VAL')
@@ -114,14 +114,17 @@ pv_doc = """PV(pvname)
       mypv.get()
       mypv.put(value)
       print mypv.pvname, mypv.count, mypv.type
- 
+
     Notes
     -----
       A PV has many attributes and methods.  Consult the documentation.
 """
 
 
-plugins = {}
+def nullfcn(*args, **kwargs): return None
+
+plugins = {'PV': nullfcn, 'caget': nullfcn, 'caput': nullfcn, 'cainfo': nullfcn,
+           'pv_units': nullfcn, 'pv_fullname': nullfcn}
 
 try:
     import epics
@@ -153,7 +156,7 @@ else:
     Returns
     -------
        string with units
-      
+
     """
         try:
             units = pv.units
@@ -173,7 +176,7 @@ else:
     Returns
     -------
        string with full PV name
-      
+
     """
 
         if  '.' not in name:
@@ -189,4 +192,3 @@ def initializeLarchPlugin(_larch=None):
 
 def registerLarchPlugin():
     return ('_epics', plugins)
-

--- a/plugins/epics/spec_emulator.py
+++ b/plugins/epics/spec_emulator.py
@@ -36,11 +36,9 @@ use_plugin_path('io')
 from fileutils import get_homedir, get_timestamp
 
 use_plugin_path('epics')
-
 from stepscan   import LarchStepScan
 from positioner import Positioner
 from detectors  import get_detector, Counter
-# from spec_config import SpecConfig
 
 
 class SpykConfig(object):

--- a/plugins/epics/stepscan.py
+++ b/plugins/epics/stepscan.py
@@ -94,18 +94,20 @@ from datetime import timedelta
 from epics  import PV, get_pv, poll, caput, caget
 
 
-from larch import Group, ValidateLarchPlugin
+from larch import Group, ValidateLarchPlugin, use_plugin_path
 from larch.utils import debugtime
 
-from larch_plugins.epics import (Counter, ArrayCounter,
-                                 DeviceCounter, Trigger,
-                                 AreaDetector, get_detector)
+use_plugin_path('epics')
 
-from larch_plugins.epics.datafile import ASCIIScanFile
-from larch_plugins.epics.positioner import Positioner
-from larch_plugins.epics import ScanDB, ScanDBException, ScanDBAbort
+from detectors import (Counter, ArrayCounter, DeviceCounter, Trigger,
+                       AreaDetector, get_detector)
+from datafile import ASCIIScanFile
+from positioner import Positioner
 
-from larch_plugins.io import fix_varname
+from scandb import ScanDB, ScanDBException, ScanDBAbort
+
+use_plugin_path('io')
+from fileutils import fix_varname
 
 MODNAME = '_scan'
 SCANDB_NAME = '%s._scandb' % MODNAME

--- a/plugins/epics/xrf_detectors.py
+++ b/plugins/epics/xrf_detectors.py
@@ -4,17 +4,11 @@ from functools import partial
 import epics
 from epics.devices.mca import  MultiXMAP
 from epics.devices.struck import Struck
-
 from epics.wx import EpicsFunction, DelayedEpicsCallback
 
-from larch import use_plugin_path
-
-use_plugin_path('xrf')
-from mca import MCA
-from roi import ROI
-
-use_plugin_path('epics')
-from xspress3 import Xspress3
+from larch_plugins.xrf import MCA, ROI
+from larch_plugins.epics.xspress3 import Xspress3
+ROI, MCA = None, None
 
 class Epics_Xspress3(object):
     """multi-element MCA detector using Quantum Xspress3 electronics 3-1-10
@@ -84,7 +78,7 @@ class Epics_Xspress3(object):
             nframes   = int((dtime+frametime*0.1)/frametime)
         self._xsp3.NumImages = nframes
         self._xsp3.AcquireTime = self.frametime = frametime
-        
+
     def get_mca(self, mca=1, with_rois=True):
         if self._xsp3 is None:
             self.connect()
@@ -116,7 +110,7 @@ class Epics_Xspress3(object):
             out = 1.0*self._xsp3.get('ARRSUM%i:ArrayData' % mca)
         except TypeError:
             out = np.arange(self.npts)*0.91
-            
+
         if len(out) != self.npts:
             self.npts = len(out)
         out[np.where(out<0.91)]= 0.91
@@ -125,14 +119,14 @@ class Epics_Xspress3(object):
     def start(self):
         'xspress3 start '
         self.stop()
-        self._xsp3.start(capture=False) 
+        self._xsp3.start(capture=False)
         time.sleep(0.01)
 
     def stop(self, timeout=0.5):
         self._xsp3.stop()
         t0 = time.time()
         while self._xsp3.Acquire_RBV == 1 and time.time()-t0 < timeout:
-            self._xsp3.stop()                
+            self._xsp3.stop()
             time.sleep(0.005)
 
     def erase(self):
@@ -208,7 +202,7 @@ class Epics_Xspress3(object):
         mca1 = self.get_mca(mca=1)
         npts = len(mca1.counts)
         fp = open(filename, 'w')
-        fp.write('VERSION:    3.1\n') 
+        fp.write('VERSION:    3.1\n')
         fp.write('ELEMENTS:   %i\n' % nelem)
         fp.write('DATE:       %s\n' % time.ctime())
         fp.write('CHANNELS:   %i\n' % npts)
@@ -392,4 +386,3 @@ class Epics_MultiXMAP(object):
 
     def save_mca(self, fname):
         buff = self._xmap
-        

--- a/plugins/epics/xrfcontrol.py
+++ b/plugins/epics/xrfcontrol.py
@@ -35,10 +35,21 @@ from wxutils import (SimpleText, EditableListBox, Font, FloatCtrl,
                      Choice, FileOpen, FileSave, fix_filename, HLine,
                      GridPanel, CEN, LEFT, RIGHT)
 
-import larch
-from larch_plugins.wx import (PeriodicTablePanel, XRFDisplayFrame,
-                              FILE_WILDCARDS, CalibrationFrame)
-from larch_plugins.epics import Epics_MultiXMAP, Epics_Xspress3
+
+from larch import use_plugin_path
+
+use_plugin_path('wx')
+from periodictable import PeriodicTablePanel
+from xrfdisplay import XRFDisplayFrame, FILE_WILDCARDS
+
+from xrfdisplay_utils import CalibrationFrame
+
+use_plugin_path('std')
+from debugtime import DebugTimer
+
+use_plugin_path('epics')
+from xrf_detectors import Epics_MultiXMAP, Epics_Xspress3
+
 
 class DetectorSelectDialog(wx.Dialog):
     """Connect to an Epics MCA detector

--- a/plugins/epics/xrfcontrol.py
+++ b/plugins/epics/xrfcontrol.py
@@ -35,21 +35,11 @@ from wxutils import (SimpleText, EditableListBox, Font, FloatCtrl,
                      Choice, FileOpen, FileSave, fix_filename, HLine,
                      GridPanel, CEN, LEFT, RIGHT)
 
-from larch import use_plugin_path
+import larch
+from larch_plugins.wx import (PeriodicTablePanel, XRFDisplayFrame,
+                              FILE_WILDCARDS, CalibrationFrame)
+from larch_plugins.epics import Epics_MultiXMAP, Epics_Xspress3
 
-# use_plugin_path('xray')
-use_plugin_path('wx')
-from periodictable import PeriodicTablePanel
-from xrfdisplay import XRFDisplayFrame, FILE_WILDCARDS
-
-from xrfdisplay_utils import CalibrationFrame
-
-use_plugin_path('std')
-from debugtime import DebugTimer
-
-use_plugin_path('epics')
-from xrf_detectors import Epics_MultiXMAP, Epics_Xspress3
-        
 class DetectorSelectDialog(wx.Dialog):
     """Connect to an Epics MCA detector
     Can be either XIA xMAP  or Quantum XSPress3
@@ -348,8 +338,8 @@ class EpicsXRFDisplayFrame(XRFDisplayFrame):
         b1 =  Button(pane, 'Start',      size=(90, 25), action=self.onStart)
         b2 =  Button(pane, 'Stop',       size=(90, 25), action=self.onStop)
         b3 =  Button(pane, 'Erase',      size=(90, 25), action=self.onErase)
-        b4 =  Button(pane, 'Continuous', size=(90, 25), action=partial(self.onStart, 
-                                                                      dtime=0))  
+        b4 =  Button(pane, 'Continuous', size=(90, 25), action=partial(self.onStart,
+                                                                      dtime=0))
 
         psizer.Add(SimpleText(pane, 'Background MCA: '), (0, 2), (1, 1), style, 1)
         psizer.Add(self.wids['bkg_det'],                 (1, 2), (1, 1), style, 1)
@@ -384,7 +374,7 @@ class EpicsXRFDisplayFrame(XRFDisplayFrame):
 
     # def update_mca(self, counts, **kws):
     #    self.det.needs_refresh = False
-                   
+
     def UpdateData(self, event=None, force=False):
         self.timer_counter += 1
         if self.mca is None or self.needs_newplot:
@@ -541,7 +531,7 @@ class EpicsXRFDisplayFrame(XRFDisplayFrame):
         confirmed = XRFDisplayFrame.onNewROI(self)
         if confirmed:
             print 'NEW ROI ' , self.det, roiname, self.xmarker_left, self.xmarker_right
-            self.det.add_roi(roiname, lo=self.xmarker_left, 
+            self.det.add_roi(roiname, lo=self.xmarker_left,
                              hi=self.xmarker_right)
 
     def onRenameROI(self, event=None):
@@ -576,11 +566,11 @@ class EpicsXRFDisplayFrame(XRFDisplayFrame):
 
     def onClose(self, event=None):
         self.onStop()
-        XRFDisplayFrame.onClose(self)        
+        XRFDisplayFrame.onClose(self)
 
     def onExit(self, event=None):
         self.onStop()
-        XRFDisplayFrame.onExit(self)        
+        XRFDisplayFrame.onExit(self)
 
 class EpicsXRFApp(wx.App, wx.lib.mixins.inspection.InspectionMixin):
     def __init__(self, **kws):
@@ -597,5 +587,5 @@ class EpicsXRFApp(wx.App, wx.lib.mixins.inspection.InspectionMixin):
 if __name__ == "__main__":
     # e = EpicsXRFApp(prefix='QX4:', det_type='ME-4',
     #                amp_type='xspress3', nmca=4)
-   
+
     EpicsXRFApp().MainLoop()

--- a/plugins/io/__init__.py
+++ b/plugins/io/__init__.py
@@ -4,12 +4,13 @@ from .fileutils import (increment_filename, new_filename, new_dirname,
                         winpath, nativepath, strip_quotes, get_timestamp)
 
 from .columnfile import read_ascii, write_ascii, write_group, iso8601_time
-from .tiff_plugin import read_tiff, tiff_object
-from .xdi import read_xdi
+from .xdi import read_xdi, XDIFile
 from .mda import read_mda
 
 from .hdf5group import h5file, h5group, netcdf_file, netcdf_group
 
 from .gse_escan import gsescan_group, gsescan_deadtime_correct
-from .gse_xdiscan import read_gsexdi, gsexdi_deadtime_correct
-from .gse_mcafile import gsemca_group
+from .gse_xdiscan import read_gsexdi, gsexdi_deadtime_correct, is_GSEXDI
+from .gse_mcafile import gsemca_group, GSEMCA_File
+from .save_restore import save, restore
+from .tiff_plugin import read_tiff, tiff_object

--- a/plugins/io/__init__.py
+++ b/plugins/io/__init__.py
@@ -1,24 +1,15 @@
-from larch.plugins.io import tifffile
-imread   = tifffile.imread
-imshow   = tifffile.imshow
-TIFFfile = tifffile.TIFFfile
 
-from larch.plugins.io import columnfile, fileutils, xdi
+from .fileutils import (increment_filename, new_filename, new_dirname,
+                        fix_filename, fix_varname, pathOf, unixpath,
+                        winpath, nativepath, strip_quotes, get_timestamp)
 
-read_xdi = xdi.read_xdi
+from .columnfile import read_ascii, write_ascii, write_group, iso8601_time
+from .tiff_plugin import read_tiff, tiff_object
+from .xdi import read_xdi
+from .mda import read_mda
 
-read_ascii = columnfile._read_ascii
-write_ascii = columnfile.write_ascii
-write_group = columnfile.write_group
+from .hdf5group import h5file, h5group, netcdf_file, netcdf_group
 
-increment_filename = fileutils.increment_filename
-new_filename = fileutils.new_filename
-new_dirname = fileutils.new_dirname
-fix_filename = fileutils.fix_filename
-fix_varname = fileutils.fix_varname
-pathOf = fileutils.pathOf
-unixpath = fileutils.unixpath
-winpath = fileutils.winpath
-nativepath = fileutils.nativepath
-strip_quotes = fileutils.strip_quotes
-get_timestamp = fileutils.get_timestamp
+from .gse_escan import gsescan_group, gsescan_deadtime_correct
+from .gse_xdiscan import read_gsexdi, gsexdi_deadtime_correct
+from .gse_mcafile import gsemca_group

--- a/plugins/io/columnfile.py
+++ b/plugins/io/columnfile.py
@@ -30,7 +30,7 @@ def iso8601_time(ts):
     s = time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(ts))
     return "%s%s" % (s, tzone)
 
-def _read_ascii(fname, labels=None, sort=False, sort_column=0, _larch=None):
+def read_ascii(fname, labels=None, sort=False, sort_column=0, _larch=None):
     """read a column ascii column file, returning a group containing the data from the file.
 
     read_ascii(filename, labels=None, sort=False, sort_column=0)
@@ -387,9 +387,8 @@ def write_group(filename, group, scalars=None,
                 label=label, header=header, _larch=_larch)
 
 def registerLarchPlugin():
-    return (MODNAME, {'read_ascii': _read_ascii,
-                      'read_ascii0': _read_ascii0,
+    return (MODNAME, {'read_ascii': read_ascii,
+                      # 'read_ascii0': _read_ascii0,
                       'write_ascii': write_ascii,
                       'write_group': write_group,
                      })
-

--- a/plugins/io/gse_escan.py
+++ b/plugins/io/gse_escan.py
@@ -8,8 +8,8 @@ import gc
 
 import numpy
 from larch import ValidateLarchPlugin, use_plugin_path
-use_plugin_path('io')
-from columnfile import iso8601_time
+
+from .columnfile import iso8601_time
 
 def _cleanfile(x):
     for o in ' ./?(){}[]",&%^#@$': x = x.replace(o,'_')
@@ -922,4 +922,3 @@ def registerLarchPlugin():
     return ('_io', {'read_gsescan': gsescan_group,
                     'gsescan_dtcorrect': gsescan_deadtime_correct,
     })
-

--- a/plugins/io/gse_escan.py
+++ b/plugins/io/gse_escan.py
@@ -9,7 +9,7 @@ import gc
 import numpy
 from larch import ValidateLarchPlugin, use_plugin_path
 
-from .columnfile import iso8601_time
+from larch_plugins.io import iso8601_time
 
 def _cleanfile(x):
     for o in ' ./?(){}[]",&%^#@$': x = x.replace(o,'_')

--- a/plugins/io/gse_mcafile.py
+++ b/plugins/io/gse_mcafile.py
@@ -5,11 +5,9 @@ import copy
 import numpy as np
 from scipy.interpolate import UnivariateSpline
 
-from larch import use_plugin_path, Group, param_value, Parameter, Interpreter
-use_plugin_path('xrf')
+from larch import Group, param_value, Parameter, Interpreter
 
-from mca import MCA
-from roi import ROI
+from larch_plugins.xrf import MCA, ROI
 
 def str2floats(s, delim='&'):
     s = s.replace('&', ' ')

--- a/plugins/io/gse_xdiscan.py
+++ b/plugins/io/gse_xdiscan.py
@@ -11,8 +11,7 @@ from larch import Group, ValidateLarchPlugin, use_plugin_path
 from larch.utils import OrderedDict
 
 
-from .xdi import XDIFile
-from .columnfile import iso8601_time
+from larch_plugins.io import XDIFile, iso8601_time
 
 use_plugin_path('xrfmap')
 from xsp3_hdf5 import XSPRESS3_TAUS, estimate_icr

--- a/plugins/io/gse_xdiscan.py
+++ b/plugins/io/gse_xdiscan.py
@@ -10,9 +10,9 @@ import numpy as np
 from larch import Group, ValidateLarchPlugin, use_plugin_path
 from larch.utils import OrderedDict
 
-use_plugin_path('io')
-from xdi import XDIFile
-from columnfile import iso8601_time
+
+from .xdi import XDIFile
+from .columnfile import iso8601_time
 
 use_plugin_path('xrfmap')
 from xsp3_hdf5 import XSPRESS3_TAUS, estimate_icr
@@ -41,7 +41,7 @@ def read_gsexdi(fname, _larch=None, nmca=4, **kws):
             except:
                 pass
             setattr(group, "%s_%s" % (family, key), val)
-        
+
     ocrs, icrs = [], []
     ctime = xdi.CountTime
     is_xspress3 = any(['13QX4' in a[1] for a in xdi.attrs['column'].items()])
@@ -73,7 +73,7 @@ def read_gsexdi(fname, _larch=None, nmca=4, **kws):
             datraw = dat*1.0
             rawname = sumname + '_nodtc'
             dat   = dat * icrs[imca]/ ocrs[imca]
-            
+
         setattr(group, aname, dat)
         if sumname not in labels:
             labels.append(sumname)
@@ -82,7 +82,7 @@ def read_gsexdi(fname, _larch=None, nmca=4, **kws):
                 sums[rawname] = datraw
                 if rawname not in labels:
                     labels.append(rawname)
-                
+
         else:
             sums[sumname] = sums[sumname] + dat
             if rawname != sumname:
@@ -101,7 +101,7 @@ def read_gsexdi(fname, _larch=None, nmca=4, **kws):
         setattr(group, 'ocr_mca%i' % (imca+1), ocrs[imca])
         setattr(group, 'icr_mca%i' % (imca+1), icrs[imca])
 
-            
+
     group.array_labels = labels
     return group
 
@@ -128,8 +128,8 @@ def is_GSEXDI(filename):
     """
     line1 = open(filename, 'r').readline()
     return (line1.startswith('#XDI/1') and 'Epics StepScan File' in line1)
-    
-    
+
+
 @ValidateLarchPlugin
 def gsexdi_deadtime_correct(fname, channelname, subdir='DT_Corrected', _larch=None):
     """convert GSE XDI fluorescence XAFS scans to dead time corrected files"""
@@ -147,15 +147,15 @@ def gsexdi_deadtime_correct(fname, channelname, subdir='DT_Corrected', _larch=No
 
     if hasattr(xdi, 'energy_readback'):
         out.energy = xdi.energy_readback
-    
+
     mono_cut = 'Si(111)'
     if xdi.mono_dspacing < 2:
         mono_cut = 'Si(311)'
     header_args = {'mono_dspace': xdi.mono_dspacing, 'mono_cut': mono_cut}
-              
+
     arrname = None
     channelname = channelname.lower().replace(' ', '_')
-    
+
     for arr in xdi.array_labels:
         if arr.lower().startswith(channelname):
             arrname = arr
@@ -177,10 +177,10 @@ def gsexdi_deadtime_correct(fname, channelname, subdir='DT_Corrected', _larch=No
 
     arrlabel = ['#', ' energy ', ' mufluor ', ' i0  ', ' fluor_dtc',
                 ' fluor_raw', ' counttime']
-    
+
     header = DTC_header % header_args
     buff   = [l.strip() for l in header.split('\n')]
-    
+
     has_i1, has_i2 = False, False
     if hasattr(out, 'i1'):
         ncol += 1
@@ -191,7 +191,7 @@ def gsexdi_deadtime_correct(fname, channelname, subdir='DT_Corrected', _larch=No
         ncol += 1
         buff.append('# Column.%i: irefer ' % ncol)
         arrlabel.append(' irefer ')
-        has_i2 = True        
+        has_i2 = True
     arrlabel = '       '.join(arrlabel)
 
     buff.extend(["# Scan.start_time: %s" % out.scan_start_time,
@@ -229,4 +229,3 @@ def gsexdi_deadtime_correct(fname, channelname, subdir='DT_Corrected', _larch=No
 def registerLarchPlugin():
     return ('_io', {'read_gsexdi': read_gsexdi,
                     'gsexdi_deadtime_correct': gsexdi_deadtime_correct})
-

--- a/plugins/io/mda.py
+++ b/plugins/io/mda.py
@@ -872,7 +872,7 @@ def opMDA(op, d1, d2):
         print("opMDA supports up to 4D scans")
     return s
 
-def _readmda(fname, maxdim=4, verbose=False, _larch=None, **kws):
+def read_mda(fname, maxdim=4, verbose=False, _larch=None, **kws):
     """read an MDA file from the Epics Scan Record
 
     Warning: not very well tested for scans of high dimension
@@ -893,4 +893,4 @@ def _readmda(fname, maxdim=4, verbose=False, _larch=None, **kws):
 
 
 def registerLarchPlugin():
-    return ('_io', {'read_mda': _readmda})
+    return ('_io', {'read_mda': read_mda})

--- a/plugins/io/save_restore.py
+++ b/plugins/io/save_restore.py
@@ -5,7 +5,7 @@ from larch import Group, Parameter, isParameter
 from larch import ValidateLarchPlugin
 from larch.utils import fixName
 
-from larch.plugins.xafs import (FeffPathGroup, FeffDatFile,
+from larch_plugins.xafs import (FeffPathGroup, FeffDatFile,
                                 FeffitDataSet, TransformGroup)
 
 class H5PySaveFile(object):

--- a/plugins/io/save_restore.py
+++ b/plugins/io/save_restore.py
@@ -5,6 +5,7 @@ from larch import Group, Parameter, isParameter
 from larch import ValidateLarchPlugin
 from larch.utils import fixName
 
+
 class H5PySaveFile(object):
     def __init__(self, fname, _larch=None):
         self.fname = fname
@@ -169,6 +170,7 @@ def restore(fname,  group=None, _larch=None):
 
     from larch_plugins.xafs import (FeffPathGroup, FeffDatFile,
                                     FeffitDataSet, TransformGroup)
+
     def make_group(h5group):
         creators = {'TransformGroup': TransformGroup,
                     'FeffDatFile':    FeffDatFile,

--- a/plugins/io/save_restore.py
+++ b/plugins/io/save_restore.py
@@ -5,8 +5,6 @@ from larch import Group, Parameter, isParameter
 from larch import ValidateLarchPlugin
 from larch.utils import fixName
 
-from larch_plugins.xafs import (FeffPathGroup, FeffDatFile,
-                                FeffitDataSet, TransformGroup)
 
 class H5PySaveFile(object):
     def __init__(self, fname, _larch=None):
@@ -169,6 +167,9 @@ def restore(fname,  group=None, _larch=None):
         msg("File  '%s' is not a valid larch save file\n" % fname)
         return
     create_group = _larch.symtable.create_group
+
+    from larch_plugins.xafs import (FeffPathGroup, FeffDatFile,
+                                    FeffitDataSet, TransformGroup)
 
     def make_group(h5group):
         creators = {'TransformGroup': TransformGroup,

--- a/plugins/io/save_restore.py
+++ b/plugins/io/save_restore.py
@@ -5,7 +5,6 @@ from larch import Group, Parameter, isParameter
 from larch import ValidateLarchPlugin
 from larch.utils import fixName
 
-
 class H5PySaveFile(object):
     def __init__(self, fname, _larch=None):
         self.fname = fname
@@ -170,7 +169,6 @@ def restore(fname,  group=None, _larch=None):
 
     from larch_plugins.xafs import (FeffPathGroup, FeffDatFile,
                                     FeffitDataSet, TransformGroup)
-
     def make_group(h5group):
         creators = {'TransformGroup': TransformGroup,
                     'FeffDatFile':    FeffDatFile,

--- a/plugins/io/tiff_plugin.py
+++ b/plugins/io/tiff_plugin.py
@@ -3,7 +3,7 @@
 Read/Write TIFF Files, using tifffile.py from Christoph Gohlke
 """
 import larch
-from larch.plugins.io import imread, imshow, TIFFfile
+from .tifffile import imread, imshow, TIFFfile
 
 def read_tiff(fname, _larch=None, *args, **kws):
     """read image data from a TIFF file as an array"""

--- a/plugins/io/tiff_plugin.py
+++ b/plugins/io/tiff_plugin.py
@@ -3,7 +3,7 @@
 Read/Write TIFF Files, using tifffile.py from Christoph Gohlke
 """
 import larch
-from .tifffile import imread, imshow, TIFFfile
+from larch_plugins.io.tifffile import imread, imshow, TIFFfile
 
 def read_tiff(fname, _larch=None, *args, **kws):
     """read image data from a TIFF file as an array"""

--- a/plugins/io/xdi.py
+++ b/plugins/io/xdi.py
@@ -8,10 +8,11 @@ import ctypes.util
 
 __version__ = '1.1.0larch'
 
+from numpy import array, exp, log, sin, arcsin
+
 from larch import ValidateLarchPlugin
 from larch.larchlib import get_dll
-from larch.plugins.xray import RAD2DEG, PLANCK_HC
-from numpy import array, exp, log, sin, arcsin
+from ..xray import RAD2DEG, PLANCK_HC
 
 class XDIFileStruct(ctypes.Structure):
     "emulate XDI File"

--- a/plugins/io/xdi.py
+++ b/plugins/io/xdi.py
@@ -12,7 +12,7 @@ from numpy import array, exp, log, sin, arcsin
 
 from larch import ValidateLarchPlugin
 from larch.larchlib import get_dll
-from ..xray import RAD2DEG, PLANCK_HC
+from larch_plugins.xray import RAD2DEG, PLANCK_HC
 
 class XDIFileStruct(ctypes.Structure):
     "emulate XDI File"

--- a/plugins/math/__init__.py
+++ b/plugins/math/__init__.py
@@ -5,8 +5,8 @@ from .lineshapes import (gaussian, lorentzian, voigt, pvoigt, pearson7,
                          skewed_voigt, students_t, logistic, erf, erfc)
 
 from .mathutils import (as_ndarray, index_nearest, index_of, realimag,
-                        remove_dups, remove_nans2, complex_phase, _interp)
+                        remove_dups, remove_nans2, complex_phase,
+                        linregress, _interp)
 
 from .fitpeak import fit_peak
-from .smoothing import savitzky_golay, smooth
 from .convolution1D import glinbroad

--- a/plugins/math/__init__.py
+++ b/plugins/math/__init__.py
@@ -1,14 +1,12 @@
-#
-from larch.plugins.math import mathutils, lineshapes
 
-gaussian = lineshapes.gaussian
-lorenztian = lineshapes.lorentzian
-voigt = lineshapes.voigt
+from .lineshapes import (gaussian, lorentzian, voigt, pvoigt, pearson7,
+                         wofz, lognormal, gammaln, breit_wigner,
+                         damped_oscillator, exgaussian, donaich,
+                         skewed_voigt, students_t, logistic, erf, erfc)
 
-index_nearest = mathutils.index_nearest
-index_of = mathutils.index_of
-realimag = mathutils.realimag
-remove_dups = mathutils.remove_dups
-remove_nans2 = mathutils.remove_nans2
-complex_phase = mathutils.complex_phase
-_interp = mathutils._interp
+from .mathutils import (as_ndarray, index_nearest, index_of, realimag,
+                        remove_dups, remove_nans2, complex_phase, _interp)
+
+from .fitpeak import fit_peak
+from .smoothing import savitzky_golay, smooth
+from .convolution1D import glinbroad

--- a/plugins/math/convolution1D.py
+++ b/plugins/math/convolution1D.py
@@ -48,7 +48,7 @@ from datetime import date
 from string import Template
 import numpy as np
 
-from .lineshapes import gaussian, lorentzian
+from larch_plugins.math.lineshapes import gaussian, lorentzian
 
 def get_ene_index(ene, cen, hwhm):
     """ returns the min/max indexes for array ene at (cen-hwhm) and (cen+hwhm)

--- a/plugins/math/convolution1D.py
+++ b/plugins/math/convolution1D.py
@@ -48,7 +48,7 @@ from datetime import date
 from string import Template
 import numpy as np
 
-from larch.plugins.math import gaussian, lorentzian
+from .lineshapes import gaussian, lorentzian
 
 def get_ene_index(ene, cen, hwhm):
     """ returns the min/max indexes for array ene at (cen-hwhm) and (cen+hwhm)

--- a/plugins/math/fitpeak.py
+++ b/plugins/math/fitpeak.py
@@ -31,7 +31,7 @@ from scipy.special import gamma, gammaln, beta, betaln, erf, erfc, wofz
 
 from larch import Group, Parameter, Minimizer, fitting, ValidateLarchPlugin
 
-from larch.plugins.math import index_nearest, index_of
+from .mathutils import index_nearest, index_of
 
 VALID_BKGS = ('constant', 'linear', 'quadratic')
 

--- a/plugins/math/fitpeak.py
+++ b/plugins/math/fitpeak.py
@@ -31,7 +31,7 @@ from scipy.special import gamma, gammaln, beta, betaln, erf, erfc, wofz
 
 from larch import Group, Parameter, Minimizer, fitting, ValidateLarchPlugin
 
-from larch_plugins.math.mathutils import index_nearest, index_of
+from larch_plugins.math import index_nearest, index_of
 
 VALID_BKGS = ('constant', 'linear', 'quadratic')
 

--- a/plugins/math/fitpeak.py
+++ b/plugins/math/fitpeak.py
@@ -31,7 +31,7 @@ from scipy.special import gamma, gammaln, beta, betaln, erf, erfc, wofz
 
 from larch import Group, Parameter, Minimizer, fitting, ValidateLarchPlugin
 
-from .mathutils import index_nearest, index_of
+from larch_plugins.math.mathutils import index_nearest, index_of
 
 VALID_BKGS = ('constant', 'linear', 'quadratic')
 

--- a/plugins/math/lineshapes.py
+++ b/plugins/math/lineshapes.py
@@ -162,7 +162,7 @@ def _gamma(x):
     """gamma function"""
     return gamma(x)
 
-def _gammaln(x):
+def gammaln(x):
     """log of absolute value of gamma function"""
     return gammaln(x)
 
@@ -173,7 +173,7 @@ def registerLarchPlugin():
                       'pvoigt': pvoigt,
                       'pearson7': pearson7,
                       'lognormal': lognormal,
-                      'gammaln': _gammaln,
+                      'gammaln': gammaln,
                       'breit_wigner': breit_wigner,
                       'damped_oscillator': damped_oscillator,
                       'exgaussian': exgaussian,
@@ -184,4 +184,3 @@ def registerLarchPlugin():
                       'erf': _erf,
                       'erfc': _erfc,
                       'wofz': _wofz})
-

--- a/plugins/math/smoothing.py
+++ b/plugins/math/smoothing.py
@@ -7,8 +7,8 @@ from numpy import pi, log, exp, sqrt, arange, concatenate, convolve
 from numpy import int, abs, linalg, mat, linspace, interp, diff
 
 import larch
-from larch.plugins.math import index_of, index_nearest, realimag, remove_dups
-from larch.plugins.math import gaussian, lorentzian, voigt
+from .mathutils import index_of, index_nearest, realimag, remove_dups
+from .lineshapes import gaussian, lorentzian, voigt
 
 def lsmooth(x, sigma=1, gamma=None, form='lorentzian', npad=None):
     """convolve a 1-d array with a lorentzian, gaussian, or voigt function.

--- a/plugins/math/smoothing.py
+++ b/plugins/math/smoothing.py
@@ -3,12 +3,11 @@
 Smoothing routines
 
 """
-from numpy import pi, log, exp, sqrt, arange, concatenate, convolve
-from numpy import int, abs, linalg, mat, linspace, interp, diff
+from numpy import (pi, log, exp, sqrt, arange, concatenate, convolve,
+                   int, abs, linalg, mat, linspace, interp, diff)
 
-import larch
-from .mathutils import index_of, index_nearest, realimag, remove_dups
-from .lineshapes import gaussian, lorentzian, voigt
+from larch_plugins.math.mathutils import index_of, index_nearest, realimag, remove_dups
+from larch_plugins.math.lineshapes import gaussian, lorentzian, voigt
 
 def lsmooth(x, sigma=1, gamma=None, form='lorentzian', npad=None):
     """convolve a 1-d array with a lorentzian, gaussian, or voigt function.

--- a/plugins/std/__init__.py
+++ b/plugins/std/__init__.py
@@ -1,6 +1,5 @@
 #
-from larch.plugins.std import grouputils
-parse_group_args = grouputils.parse_group_args
-
-from larch.plugins.std import show
-_show = show._show
+from .grouputils import parse_group_args
+from .show import _show as show
+from .show import _get as get
+from .show import group2dict, dict2group, show_tree

--- a/plugins/wx/__init__.py
+++ b/plugins/wx/__init__.py
@@ -1,3 +1,5 @@
-
-from .xrfdisplay import XRFDisplayFrame, XRFApp
+from . import gui_utils
+from .plotter import _newplot, _plot
 from .periodictable import PeriodicTablePanel
+from .xrfdisplay import XRFDisplayFrame, XRFApp, FILE_WILDCARDS
+from .xrfdisplay_utils import CalibrationFrame

--- a/plugins/wx/__init__.py
+++ b/plugins/wx/__init__.py
@@ -5,4 +5,3 @@ from .xrfdisplay import XRFDisplayFrame, XRFApp, FILE_WILDCARDS
 from .xrfdisplay_utils import CalibrationFrame
 from .gse_dtcorrect import DTViewer
 from .scanviewer import ScanViewer
-from .xrfcontrol import EpicsXRFApp

--- a/plugins/wx/__init__.py
+++ b/plugins/wx/__init__.py
@@ -5,3 +5,4 @@ from .xrfdisplay import XRFDisplayFrame, XRFApp, FILE_WILDCARDS
 from .xrfdisplay_utils import CalibrationFrame
 from .gse_dtcorrect import DTViewer
 from .scanviewer import ScanViewer
+from .mapviewer import MapViewer

--- a/plugins/wx/__init__.py
+++ b/plugins/wx/__init__.py
@@ -3,3 +3,6 @@ from .plotter import _newplot, _plot
 from .periodictable import PeriodicTablePanel
 from .xrfdisplay import XRFDisplayFrame, XRFApp, FILE_WILDCARDS
 from .xrfdisplay_utils import CalibrationFrame
+from .gse_dtcorrect import DTViewer
+from .scanviewer import ScanViewer
+from .xrfcontrol import EpicsXRFApp

--- a/plugins/wx/__init__.py
+++ b/plugins/wx/__init__.py
@@ -1,0 +1,3 @@
+
+from .xrfdisplay import XRFDisplayFrame, XRFApp
+from .periodictable import PeriodicTablePanel

--- a/plugins/wx/gse_dtcorrect.py
+++ b/plugins/wx/gse_dtcorrect.py
@@ -21,13 +21,12 @@ try:
     HAS_EPICS = True
 except ImportError:
     pass
-    
-from larch import Interpreter, use_plugin_path
+
+from larch import Interpreter
 from larch.larchlib import read_workdir, save_workdir
-        
-use_plugin_path('io')
-from gse_escan import gsescan_deadtime_correct
-from gse_xdiscan import gsexdi_deadtime_correct, is_GSEXDI
+
+from ..io  import (gsescan_deadtime_correct, gsexdi_deadtime_correct,
+                   is_GSEXDI)
 
 from wxutils import (SimpleText, FloatCtrl, pack, Button, Popup,
                      Choice,  Check, MenuItem, GUIColors,
@@ -38,7 +37,7 @@ FILE_WILDCARDS = "Scan Data Files(*.0*,*.dat,*.xdi)|*.0*;*.dat;*.xdi|All files (
 FNB_STYLE = flat_nb.FNB_NO_X_BUTTON|flat_nb.FNB_SMART_TABS|flat_nb.FNB_NO_NAV_BUTTONS
 
 
-WORKDIR_FILE = 'dtc_file.txt' 
+WORKDIR_FILE = 'dtc_file.txt'
 
 def okcancel(panel, onOK=None, onCancel=None):
     btnsizer = wx.StdDialogButtonSizer()
@@ -52,7 +51,7 @@ def okcancel(panel, onOK=None, onCancel=None):
     btnsizer.Realize()
     return btnsizer
 
-    
+
 class DTCorrectFrame(wx.Frame):
     _about = """GSECARS Deadtime Corrections
   Matt Newville <newville @ cars.uchicago.edu>
@@ -65,7 +64,7 @@ class DTCorrectFrame(wx.Frame):
         title = "DeadTime Correction "
         self.larch = _larch
         self.subframes = {}
-       
+
         self.SetSize((380, 180))
         self.SetFont(Font(10))
 
@@ -79,21 +78,21 @@ class DTCorrectFrame(wx.Frame):
         for i in range(len(statusbar_fields)):
             self.statusbar.SetStatusText(statusbar_fields[i], i)
         read_workdir(WORKDIR_FILE)
-        
+
     def onBrowse(self, event=None):
-        dlg = wx.FileDialog(parent=self, 
+        dlg = wx.FileDialog(parent=self,
                         message='Select Files',
                         defaultDir=os.getcwd(),
                         wildcard =FILE_WILDCARDS,
                         style=wx.OPEN|wx.MULTIPLE|wx.CHANGE_DIR)
-        
+
         if dlg.ShowModal() == wx.ID_OK:
             path = dlg.GetPath()
             mdir, p = os.path.split(path)
             os.chdir(mdir)
             roiname = self.roi_wid.GetValue().strip()
-            if len(roiname) < 1: 
-                Popup(self, 
+            if len(roiname) < 1:
+                Popup(self,
                     'Must give ROI name!', 'No ROI name')
                 return
             dirname = self.dir_wid.GetValue().strip()
@@ -101,7 +100,7 @@ class DTCorrectFrame(wx.Frame):
                 try:
                     os.mkdir(dirname)
                 except:
-                    Popup(self, 
+                    Popup(self,
                         'Could not create directory %s' % dirname,
                         "could not create directory")
                     return
@@ -114,7 +113,7 @@ class DTCorrectFrame(wx.Frame):
     def createMainPanel(self):
         panel = wx.Panel(self)
         sizer = wx.GridBagSizer(5, 4)
- 
+
         lab1 = SimpleText(panel, ' Element / ROI Name')
         lab2 = SimpleText(panel, ' Output Folder:')
         lab3 = SimpleText(panel, ' Select Files:')
@@ -122,20 +121,20 @@ class DTCorrectFrame(wx.Frame):
         self.dir_wid = wx.TextCtrl(panel, -1, 'DT_Corrected', size=(200, -1))
         self.sel_wid = Button(panel, 'Browse', size=(100, -1),
                                 action=self.onBrowse)
-        
+
         ir = 0
         sizer.Add(lab1,         (ir, 0), (1, 1), LCEN, 2)
         sizer.Add(self.roi_wid, (ir, 1), (1, 1), LCEN, 2)
         ir += 1
         sizer.Add(lab2,          (ir, 0), (1, 1), LCEN, 2)
-        sizer.Add(self.dir_wid,  (ir, 1), (1, 1), LCEN, 2)      
+        sizer.Add(self.dir_wid,  (ir, 1), (1, 1), LCEN, 2)
         ir += 1
         sizer.Add(lab3,          (ir, 0), (1, 1), LCEN, 2)
-        sizer.Add(self.sel_wid,  (ir, 1), (1, 1), LCEN, 2)              
+        sizer.Add(self.sel_wid,  (ir, 1), (1, 1), LCEN, 2)
 
         pack(panel, sizer)
         wx.CallAfter(self.init_larch)
-        return 
+        return
 
     def init_larch(self):
         t0 = time.time()
@@ -145,7 +144,7 @@ class DTCorrectFrame(wx.Frame):
         self.larch.symtable.set_symbol('_sys.wx.parent', self)
 
         self.SetStatusText('ready')
-        
+
     def write_message(self, s, panel=0):
         """write a message to the Status Bar"""
         self.SetStatusText(s, panel)
@@ -155,19 +154,19 @@ class DTCorrectFrame(wx.Frame):
         self.menubar = wx.MenuBar()
         #
         fmenu = wx.Menu()
-        
+
         MenuItem(self, fmenu, "&Quit\tCtrl+Q", "Quit program", self.onClose)
 
         self.menubar.Append(fmenu, "&File")
 
-      
+
         self.SetMenuBar(self.menubar)
 
     def onClose(self,evt):
         save_workdir(WORKDIR_FILE)
         self.Destroy()
 
-  
+
 class DTViewer(wx.App, wx.lib.mixins.inspection.InspectionMixin):
     def __init__(self, _larch=None, **kws):
         self._larch = _larch

--- a/plugins/wx/gse_dtcorrect.py
+++ b/plugins/wx/gse_dtcorrect.py
@@ -25,8 +25,8 @@ except ImportError:
 from larch import Interpreter
 from larch.larchlib import read_workdir, save_workdir
 
-from ..io  import (gsescan_deadtime_correct, gsexdi_deadtime_correct,
-                   is_GSEXDI)
+from larch_plugins.io  import (gsescan_deadtime_correct, gsexdi_deadtime_correct,
+                               is_GSEXDI)
 
 from wxutils import (SimpleText, FloatCtrl, pack, Button, Popup,
                      Choice,  Check, MenuItem, GUIColors,

--- a/plugins/wx/mapimageframe.py
+++ b/plugins/wx/mapimageframe.py
@@ -20,11 +20,6 @@ from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg
 
 import larch
 
-larch.use_plugin_path('std')
-from debugtime import DebugTimer
-
-larch.use_plugin_path('wx')
-
 from wxmplot import ImageFrame, PlotFrame
 from wxmplot.imagepanel import ImagePanel
 from wxmplot.imageconf import ColorMap_List, Interp_List
@@ -63,7 +58,6 @@ class MapImageFrame(ImageFrame):
                  show_xsections=False, cursor_labels=None,
                  output_title='Image',   **kws):
 
-        dbt = DebugTimer()
         self.det = None
         self.xrmfile = None
         self.map = None

--- a/plugins/wx/mapviewer.py
+++ b/plugins/wx/mapviewer.py
@@ -66,13 +66,13 @@ import larch
 from larch.larchlib import read_workdir, save_workdir
 from larch.wxlib import larchframe
 
-from .xrfdisplay import XRFDisplayFrame
-from .mapimageframe import MapImageFrame
+from larch_plugins.wx.xrfdisplay import XRFDisplayFrame
+from larch_plugins.wx.mapimageframe import MapImageFrame
 
-from ..io import nativepath
+from larch_plugins.io import nativepath
 
-from ..xrfmap import (GSEXRM_MapFile, GSEXRM_FileStatus,
-                      GSEXRM_Exception, GSEXRM_NotOwner)
+from larch_plugins.xrfmap import (GSEXRM_MapFile, GSEXRM_FileStatus,
+                                  GSEXRM_Exception, GSEXRM_NotOwner)
 
 CEN = wx.ALIGN_CENTER|wx.ALIGN_CENTER_VERTICAL
 LEFT = wx.ALIGN_LEFT|wx.ALIGN_CENTER_VERTICAL

--- a/plugins/wx/mapviewer.py
+++ b/plugins/wx/mapviewer.py
@@ -65,18 +65,14 @@ from wxutils import (SimpleText, EditableListBox, FloatCtrl, Font,
 import larch
 from larch.larchlib import read_workdir, save_workdir
 from larch.wxlib import larchframe
-larch.use_plugin_path('wx')
-larch.use_plugin_path('io')
-larch.use_plugin_path('xrfmap')
-larch.use_plugin_path('std')
 
-from xrfdisplay import XRFDisplayFrame
-from mapimageframe import MapImageFrame
+from .xrfdisplay import XRFDisplayFrame
+from .mapimageframe import MapImageFrame
 
-from fileutils import nativepath
+from ..io import nativepath
 
-from xrm_mapfile import (GSEXRM_MapFile, GSEXRM_FileStatus,
-                         GSEXRM_Exception, GSEXRM_NotOwner)
+from ..xrfmap import (GSEXRM_MapFile, GSEXRM_FileStatus,
+                      GSEXRM_Exception, GSEXRM_NotOwner)
 
 CEN = wx.ALIGN_CENTER|wx.ALIGN_CENTER_VERTICAL
 LEFT = wx.ALIGN_LEFT|wx.ALIGN_CENTER_VERTICAL

--- a/plugins/wx/plotter.py
+++ b/plugins/wx/plotter.py
@@ -28,9 +28,9 @@ from wxmplot import PlotFrame, ImageFrame
 
 import larch
 
-from .gui_utils import ensuremod
-from .xrfdisplay import XRFDisplayFrame
-from ..xrf import isLarchMCAGroup
+from larch_plugins.wx.gui_utils import ensuremod
+from larch_plugins.wx.xrfdisplay import XRFDisplayFrame
+from larch_plugins.xrf import isLarchMCAGroup
 
 mpl_dir = os.path.join(larch.site_config.larchdir, 'matplotlib')
 os.environ['MPLCONFIGDIR'] = mpl_dir

--- a/plugins/wx/plotter.py
+++ b/plugins/wx/plotter.py
@@ -27,12 +27,10 @@ import wx.lib.newevent
 from wxmplot import PlotFrame, ImageFrame
 
 import larch
-larch.use_plugin_path('wx')
-from gui_utils import ensuremod
-from xrfdisplay import XRFDisplayFrame
 
-larch.use_plugin_path('xrf')
-from mca import isLarchMCAGroup
+from .gui_utils import ensuremod
+from .xrfdisplay import XRFDisplayFrame
+from ..xrf import isLarchMCAGroup
 
 mpl_dir = os.path.join(larch.site_config.larchdir, 'matplotlib')
 os.environ['MPLCONFIGDIR'] = mpl_dir

--- a/plugins/wx/scanviewer.py
+++ b/plugins/wx/scanviewer.py
@@ -26,22 +26,18 @@ try:
     HAS_EPICS = True
 except ImportError:
     pass
-    
-from larch import Interpreter, use_plugin_path, isParameter
+
+from larch import Interpreter, isParameter
 from larch.larchlib import read_workdir, save_workdir
 from larch.wxlib import larchframe
 from larch.fitting import fit_report
-from larch.utils import debugtime        
-use_plugin_path('math')
-from fitpeak import fit_peak
-from mathutils import index_of
+from larch.utils import debugtime
 
-use_plugin_path('io')
-from gse_escan import gsescan_group
-from xdi import read_xdi
+from ..math import fit_peak, index_of
 
-use_plugin_path('wx')
-from mapviewer import MapViewerFrame
+from ..io import gsescan_group, read_xdi
+
+from .mapviewer import MapViewerFrame
 
 from wxmplot import PlotFrame, PlotPanel
 
@@ -74,7 +70,7 @@ def okcancel(panel, onOK=None, onCancel=None):
     btnsizer.Realize()
     return btnsizer
 
- 
+
 class EditColumnFrame(wx.Frame) :
     """Set Column Labels for a file"""
     def __init__(self, parent, pos=(-1, -1)):
@@ -88,7 +84,7 @@ class EditColumnFrame(wx.Frame) :
         wx.Frame.__init__(self, None, -1, 'Edit Column Labels',
                           style=FRAMESTYLE)
 
-        FWID = 600 
+        FWID = 600
         self.SetFont(Font(10))
         sizer = wx.GridBagSizer(10, 5)
         panel = scrolled.ScrolledPanel(self)
@@ -158,7 +154,7 @@ class EditColumnFrame(wx.Frame) :
         self.Raise()
 
     def onOK(self, event=None):
-        """ rename labels -- note that values for new names are first gathered, 
+        """ rename labels -- note that values for new names are first gathered,
         and then set, so that renaming 'a' and 'b' works."""
         labels = []
         tmp = {}
@@ -197,7 +193,7 @@ class ScanViewerFrame(wx.Frame):
         self.SetFont(Font(10))
 
         self.config = {'chdir_on_fileopen': True}
-        
+
         self.createMainPanel()
         self.createMenus()
         self.statusbar = self.CreateStatusBar(2, 0)
@@ -278,7 +274,7 @@ class ScanViewerFrame(wx.Frame):
         self.dtcorr   = Check(panel, default=True, label='correct deadtime?',
                               action=self.onColumnChoices)
         ir += 1
-        sizer.Add(self.use_deriv, (ir,   0), (1, 3), LCEN, 0)       
+        sizer.Add(self.use_deriv, (ir,   0), (1, 3), LCEN, 0)
         sizer.Add(self.dtcorr,    (ir,   3), (1, 3), LCEN, 0)
 
         pack(panel, sizer)
@@ -312,7 +308,7 @@ class ScanViewerFrame(wx.Frame):
         pack(btnbox, btnsizer)
         mainsizer.Add(btnbox, 0, LCEN, 2)
         mainsizer.Add(self.nb, 1, LCEN|wx.EXPAND, 2)
-        
+
         pack(mainpanel, mainsizer)
 
         return mainpanel
@@ -347,10 +343,10 @@ class ScanViewerFrame(wx.Frame):
 
         self.fit_report = RichTextCtrl(panel,  size=(525, 250),
                                      style=wx.VSCROLL|wx.NO_BORDER)
-        
+
         self.fit_report.SetEditable(False)
         self.fit_report.SetFont(Font(9))
-        
+
 
         sizer = wx.BoxSizer(wx.VERTICAL)
         sizer.Add(tpan, 0, wx.GROW|wx.ALL, 2)
@@ -540,7 +536,7 @@ class ScanViewerFrame(wx.Frame):
                       marker='None', markersize=4)
         popts2 = dict(style='short dashed', linewidth=2, zorder=-5,
                       marker='None', markersize=4)
-        poptsd = dict(style='solid', linewidth=2, zorder=-5, 
+        poptsd = dict(style='solid', linewidth=2, zorder=-5,
                       side='right',  y2label='derivative',
                       marker='None', markersize=4)
 
@@ -616,7 +612,7 @@ class ScanViewerFrame(wx.Frame):
         y2  = self.yarr[1].GetStringSelection()
         y3  = self.yarr[2].GetStringSelection()
 
-        array_sel = {'xop': xop, 'xarr': x, 
+        array_sel = {'xop': xop, 'xarr': x,
                      'op1': op1, 'op2': op2, 'op3': op3,
                      'y1': y1, 'y2': y2, 'y3': y3,
                      'dtcorr': dtcorr, 'use_deriv': use_deriv}
@@ -671,10 +667,10 @@ class ScanViewerFrame(wx.Frame):
         lgroup._y1 = y1
         lgroup._y2 = y2
         lgroup._y3 = y3
-        
+
         self.larch("%s._xdat_ = %s(%s._x)" % (gname, xop, gname))
         try:
-            yexpr = "%s._ydat_ = %s((%s._y1 %s %s._y2) %s %s._y3)"  % (gname, 
+            yexpr = "%s._ydat_ = %s((%s._y1 %s %s._y2) %s %s._y3)"  % (gname,
                     op1, gname, op2, gname, op3, gname)
             self.larch(yexpr)
         except RuntimeWarning:
@@ -705,9 +701,9 @@ class ScanViewerFrame(wx.Frame):
             self.xas_process(self.groupname, new_mu=True)
         else:
             lgroup.plot_yarrays = [(lgroup._ydat_, {}, None)]
-        
+
     def onPlot(self, evt=None, opt='new', npts=None, reprocess=False):
-           
+
         try:
             self.plotframe.Show()
         except: #  wx.PyDeadObjectError
@@ -742,7 +738,7 @@ class ScanViewerFrame(wx.Frame):
 
         if not hasattr(lgroup, '_xdat_'):
             self.onColumnChoices()
-            
+
         lgroup._xdat_ = np.array( lgroup._xdat_[:npts])
         plot_yarrays = [(lgroup._ydat_, {}, None)]
         if hasattr(lgroup, 'plot_yarrays'):
@@ -789,7 +785,7 @@ class ScanViewerFrame(wx.Frame):
     def onShowLarchBuffer(self, evt=None):
         if self.larch_buffer is None:
             self.larch_buffer = larchframe.LarchFrame(_larch=self.larch)
-        
+
         self.larch_buffer.Show()
         self.larch_buffer.Raise()
 
@@ -797,7 +793,7 @@ class ScanViewerFrame(wx.Frame):
         if groupname is None and evt is not None:
             fpath = self.file_paths[evt.GetInt()]
             groupname = self.file_groups[fpath]
-            
+
         if not hasattr(self.datagroups, groupname):
             print( 'Error reading file ', groupname)
             return
@@ -834,7 +830,7 @@ class ScanViewerFrame(wx.Frame):
                     self.use_deriv.SetValue({True: 1, False:0}[sel['use_deriv']])
                 except:
                     pass
-            
+
     def set_array_labels(self, labels=None):
         """set choices for array dropdowns from array labels"""
         array_labels = self.lgroup.array_labels
@@ -860,7 +856,7 @@ class ScanViewerFrame(wx.Frame):
             if j == 0:
                 self.yarr[j].SetItems(ycols)
                 if _yarr[j] in ycols and len(_yarr[j]) > 0:
-                    self.yarr[j].SetStringSelection(_yarr[j])                    
+                    self.yarr[j].SetStringSelection(_yarr[j])
                 elif ycols[0] == _xarr and len(ycols)> 1:
                     self.yarr[j].SetStringSelection(ycols[1])
             else:
@@ -899,7 +895,7 @@ class ScanViewerFrame(wx.Frame):
 
 
 
-        self.menubar.Append(omenu, "Options")        
+        self.menubar.Append(omenu, "Options")
 
 
         # fmenu.AppendSeparator()
@@ -957,10 +953,10 @@ class ScanViewerFrame(wx.Frame):
         if not shown:
             self.subframes[name] = frameclass(self)
 
-        
+
     def onEditColumnLabels(self, evt=None):
         self.show_subframe('coledit', EditColumnFrame)
-       
+
     def onReadScan(self, evt=None):
         dlg = wx.FileDialog(self, message="Load Column Data File",
                             defaultDir=os.getcwd(),
@@ -985,7 +981,7 @@ class ScanViewerFrame(wx.Frame):
             parent, fname = os.path.split(path)
             if self.config['chdir_on_fileopen']:
                 os.chdir(parent)
-            
+
             fh = open(path, 'r')
             line1 = fh.readline().lower()
             fh.close()
@@ -996,7 +992,7 @@ class ScanViewerFrame(wx.Frame):
                 reader = 'read_xdi'
                 if 'epics stepscan file' in line1:
                     reader = 'read_gsexdi'
-                
+
             self.larch("%s = %s('%s')" % (gname, reader, path))
             self.larch("%s.path  = '%s'"     % (gname, path))
             self.filelist.Append(fname)
@@ -1044,5 +1040,3 @@ def registerLarchPlugin():
     return ('_plotter', {'scanviewer':_scanviewer,
                          'mapviewer':_mapviewer,
                          'larchgui':_larchgui})
-
-

--- a/plugins/wx/scanviewer.py
+++ b/plugins/wx/scanviewer.py
@@ -33,11 +33,11 @@ from larch.wxlib import larchframe
 from larch.fitting import fit_report
 from larch.utils import debugtime
 
-from ..math import fit_peak, index_of
+from larch_plugins.math import fit_peak, index_of
 
-from ..io import gsescan_group, read_xdi
+from larch_plugins.io import gsescan_group, read_xdi
 
-from .mapviewer import MapViewerFrame
+from larch_plugins.wx.mapviewer import MapViewerFrame
 
 from wxmplot import PlotFrame, PlotPanel
 

--- a/plugins/wx/xrfdisplay.py
+++ b/plugins/wx/xrfdisplay.py
@@ -38,15 +38,16 @@ from wxutils import (SimpleText, EditableListBox, Font,
                      Choice, FileOpen, FileSave, fix_filename, HLine,
                      GridPanel, CEN, LEFT, RIGHT)
 
-from .periodictable import PeriodicTablePanel
+from larch_plugins.wx.periodictable import PeriodicTablePanel
+from larch_plugins.wx.xrfdisplay_utils import (CalibrationFrame,
+                                               ColorsFrame, ROI_Averager,
+                                               XrayLinesFrame,
+                                               XRFDisplayConfig)
 
-from .xrfdisplay_utils import (CalibrationFrame, ColorsFrame, ROI_Averager,
-                               XrayLinesFrame, XRFDisplayConfig)
+from larch_plugins.wx.xrfdisplay_fitpeaks import FitSpectraFrame
 
-from .xrfdisplay_fitpeaks import FitSpectraFrame
-
-from ..math import index_of
-from ..io import GSEMCA_File, gsemca_group
+from larch_plugins.math import index_of
+from larch_plugins.io import GSEMCA_File, gsemca_group
 
 FILE_WILDCARDS = "MCA File (*.mca)|*.mca|All files (*.*)|*.*"
 FILE_ALREADY_READ = """The File

--- a/plugins/wx/xrfdisplay.py
+++ b/plugins/wx/xrfdisplay.py
@@ -31,28 +31,22 @@ try:
 except:
     pass
 
-from larch import Interpreter, use_plugin_path, site_config
-
-use_plugin_path('math')
-from mathutils import index_of
-
-use_plugin_path('xrf')
-use_plugin_path('wx')
+from larch import Interpreter, site_config
 
 from wxutils import (SimpleText, EditableListBox, Font,
                      pack, Popup, Button, get_icon, Check, MenuItem,
                      Choice, FileOpen, FileSave, fix_filename, HLine,
                      GridPanel, CEN, LEFT, RIGHT)
 
-from periodictable import PeriodicTablePanel
+from .periodictable import PeriodicTablePanel
 
-from xrfdisplay_utils import (CalibrationFrame, ColorsFrame, ROI_Averager,
-                              XrayLinesFrame, XRFDisplayConfig)
+from .xrfdisplay_utils import (CalibrationFrame, ColorsFrame, ROI_Averager,
+                               XrayLinesFrame, XRFDisplayConfig)
 
-from xrfdisplay_fitpeaks import FitSpectraFrame
+from .xrfdisplay_fitpeaks import FitSpectraFrame
 
-use_plugin_path('io')
-from gse_mcafile import GSEMCA_File, gsemca_group
+from ..math import index_of
+from ..io import GSEMCA_File, gsemca_group
 
 FILE_WILDCARDS = "MCA File (*.mca)|*.mca|All files (*.*)|*.*"
 FILE_ALREADY_READ = """The File

--- a/plugins/wx/xrfdisplay_fitpeaks.py
+++ b/plugins/wx/xrfdisplay_fitpeaks.py
@@ -13,12 +13,13 @@ import wx.lib.scrolledpanel as scrolled
 from wxutils import (SimpleText, FloatCtrl, Choice, Font, pack, Button,
                      Check, HLine, GridPanel, RowPanel, CEN, LEFT, RIGHT)
 
-from larch import use_plugin_path, Group, Parameter
+from larch import Group, Parameter
 from larch.larchlib import Empty
-use_plugin_path('xrf')
-from xrf_bgr import xrf_background
-from xrf_calib import xrf_calib_fitrois, xrf_calib_compute, xrf_calib_apply
-from materials import material_mu, material_get
+
+from ..xrf import (xrf_background, xrf_calib_fitrois,
+                   xrf_calib_compute, xrf_calib_apply)
+
+from ..xray import material_mu, material_get
 
 from parameter import ParameterPanel
 try:
@@ -380,5 +381,3 @@ class FitSpectraFrame(wx.Frame):
 
     def onClose(self, event=None):
         self.Destroy()
-
-

--- a/plugins/wx/xrfdisplay_fitpeaks.py
+++ b/plugins/wx/xrfdisplay_fitpeaks.py
@@ -16,10 +16,10 @@ from wxutils import (SimpleText, FloatCtrl, Choice, Font, pack, Button,
 from larch import Group, Parameter
 from larch.larchlib import Empty
 
-from ..xrf import (xrf_background, xrf_calib_fitrois,
-                   xrf_calib_compute, xrf_calib_apply)
+from larch_plugins.xrf import (xrf_background, xrf_calib_fitrois,
+                               xrf_calib_compute, xrf_calib_apply)
 
-from ..xray import material_mu, material_get
+from larch_plugins.xray import material_mu, material_get
 
 from parameter import ParameterPanel
 try:

--- a/plugins/wx/xrfdisplay_utils.py
+++ b/plugins/wx/xrfdisplay_utils.py
@@ -17,10 +17,8 @@ from wxmplot.colors import hexcolor
 
 import larch
 
-larch.use_plugin_path('xrf')
-
-from xrf_bgr import xrf_background
-from xrf_calib import xrf_calib_fitrois, xrf_calib_compute, xrf_calib_apply
+from ..xrf import (xrf_background, xrf_calib_fitrois,
+                   xrf_calib_compute, xrf_calib_apply)
 
 class CalibrationFrame(wx.Frame):
     def __init__(self, parent, mca, larch=None, size=(-1, -1), callback=None):
@@ -392,7 +390,7 @@ class ROI_Averager():
     """
     def __init__(self, nsamples=11):
         self.clear(nsamples = nsamples)
-        
+
     def clear(self, nsamples=11):
         self.nsamples = nsamples
         self.index = -1
@@ -408,7 +406,7 @@ class ROI_Averager():
         self.lastval  = value
         dt = time.time() - self.toffset
         # avoid first time point
-        if (idx == 0 and max(self.times) < 0): 
+        if (idx == 0 and max(self.times) < 0):
             dt = 0
         self.times[idx] =  dt
 
@@ -418,11 +416,9 @@ class ROI_Averager():
     def get_mean(self):
         valid = np.where(self.times > 0)[0]
         return self.data[valid].mean()
-    
+
     def get_cps(self):
         valid = np.where(self.times > 0)[0]
         if len(valid) < 1 or  self.times[valid].ptp() < 0.5:
             return 0
         return self.data[valid].sum() / self.times[valid].ptp()
-            
-

--- a/plugins/wx/xrfdisplay_utils.py
+++ b/plugins/wx/xrfdisplay_utils.py
@@ -17,8 +17,8 @@ from wxmplot.colors import hexcolor
 
 import larch
 
-from ..xrf import (xrf_background, xrf_calib_fitrois,
-                   xrf_calib_compute, xrf_calib_apply)
+from larch_plugins.xrf import (xrf_background, xrf_calib_fitrois,
+                               xrf_calib_compute, xrf_calib_apply)
 
 class CalibrationFrame(wx.Frame):
     def __init__(self, parent, mca, larch=None, size=(-1, -1), callback=None):

--- a/plugins/xafs/__init__.py
+++ b/plugins/xafs/__init__.py
@@ -1,33 +1,14 @@
+from .xafsutils import KTOE, ETOK, set_xafsGroup
+from .pre_edge import preedge, find_e0, pre_edge
+from .xafsft import xftf, xftr, xftf_fast, xftr_fast, ftwindow
 
-from larch.plugins.xafs import xafsutils
+from .feffdat import FeffPathGroup, FeffDatFile, _ff2chi
+from .feffit import FeffitDataSet, TransformGroup
 
-KTOE = xafsutils.KTOE
-ETOK = xafsutils.ETOK
-set_xafsGroup = xafsutils.set_xafsGroup
+from .autobk import autobk
+from .mback import mback
+from .diffkk import diffkk
 
-from larch.plugins.xafs import pre_edge
-preedge = pre_edge.preedge
-find_e0 = pre_edge.find_e0
-# pre_edge = _preEdgeMod.pre_edge # note order!
-
-from larch.plugins.xafs import xafsft
-xftf = xafsft.xftf
-xftr = xafsft.xftr
-xftf_fast = xafsft.xftf_fast
-xftr_fast = xafsft.xftr_fast
-ftwindow  = xafsft.ftwindow
-
-
-from larch.plugins.xafs import feffdat
-FeffPathGroup = feffdat.FeffPathGroup
-FeffDatFile = feffdat.FeffDatFile
-_ff2chi = feffdat._ff2chi
-
-
-from larch.plugins.xafs import feffit
-FeffitDataSet = feffit.FeffitDataSet
-TransformGroup = feffit.TransformGroup
-
-
-from larch.plugins.xafs import autobk
-from larch.plugins.xafs import mback
+from .fluo import fluo_corr
+from .cauchy_wavelet import cauchy_wavelet
+from .deconvolve import xas_deconvolve

--- a/plugins/xafs/__init__.py
+++ b/plugins/xafs/__init__.py
@@ -1,14 +1,33 @@
-from .xafsutils import KTOE, ETOK, set_xafsGroup
-from .pre_edge import preedge, find_e0, pre_edge
-from .xafsft import xftf, xftr, xftf_fast, xftr_fast, ftwindow
 
-from .feffdat import FeffPathGroup, FeffDatFile, _ff2chi
-from .feffit import FeffitDataSet, TransformGroup
+from larch.plugins.xafs import xafsutils
 
-from .autobk import autobk
-from .mback import mback
-from .diffkk import diffkk
+KTOE = xafsutils.KTOE
+ETOK = xafsutils.ETOK
+set_xafsGroup = xafsutils.set_xafsGroup
 
-from .fluo import fluo_corr
-from .cauchy_wavelet import cauchy_wavelet
-from .deconvolve import xas_deconvolve
+from larch.plugins.xafs import pre_edge
+preedge = pre_edge.preedge
+find_e0 = pre_edge.find_e0
+# pre_edge = _preEdgeMod.pre_edge # note order!
+
+from larch.plugins.xafs import xafsft
+xftf = xafsft.xftf
+xftr = xafsft.xftr
+xftf_fast = xafsft.xftf_fast
+xftr_fast = xafsft.xftr_fast
+ftwindow  = xafsft.ftwindow
+
+
+from larch.plugins.xafs import feffdat
+FeffPathGroup = feffdat.FeffPathGroup
+FeffDatFile = feffdat.FeffDatFile
+_ff2chi = feffdat._ff2chi
+
+
+from larch.plugins.xafs import feffit
+FeffitDataSet = feffit.FeffitDataSet
+TransformGroup = feffit.TransformGroup
+
+
+from larch.plugins.xafs import autobk
+from larch.plugins.xafs import mback

--- a/plugins/xafs/__init__.py
+++ b/plugins/xafs/__init__.py
@@ -1,33 +1,15 @@
+from .xafsutils import KTOE, ETOK, set_xafsGroup
 
-from larch.plugins.xafs import xafsutils
+from .xafsft import xftf, xftr, xftf_fast, xftr_fast, ftwindow
 
-KTOE = xafsutils.KTOE
-ETOK = xafsutils.ETOK
-set_xafsGroup = xafsutils.set_xafsGroup
+from .pre_edge import pre_edge, preedge, find_e0
 
-from larch.plugins.xafs import pre_edge
-preedge = pre_edge.preedge
-find_e0 = pre_edge.find_e0
-# pre_edge = _preEdgeMod.pre_edge # note order!
-
-from larch.plugins.xafs import xafsft
-xftf = xafsft.xftf
-xftr = xafsft.xftr
-xftf_fast = xafsft.xftf_fast
-xftr_fast = xafsft.xftr_fast
-ftwindow  = xafsft.ftwindow
+from .feffdat import FeffPathGroup, FeffDatFile, _ff2chi
 
 
-from larch.plugins.xafs import feffdat
-FeffPathGroup = feffdat.FeffPathGroup
-FeffDatFile = feffdat.FeffDatFile
-_ff2chi = feffdat._ff2chi
+from .feffit import FeffitDataSet, TransformGroup, feffit
 
-
-from larch.plugins.xafs import feffit
-FeffitDataSet = feffit.FeffitDataSet
-TransformGroup = feffit.TransformGroup
-
-
-from larch.plugins.xafs import autobk
-from larch.plugins.xafs import mback
+from .autobk import autobk
+from .mback import mback
+from .diffkk import diffkk
+from .fluo import fluo_corr

--- a/plugins/xafs/autobk.py
+++ b/plugins/xafs/autobk.py
@@ -6,13 +6,12 @@ from larch import Group, Parameter, Minimizer
 from larch import ValidateLarchPlugin, isgroup
 
 # import other plugins from std, math, and xafs modules...
-from larch.plugins.std  import parse_group_args
-from larch.plugins.math import (index_of, index_nearest,
+from larch_plugins.std  import parse_group_args
+from larch_plugins.math import (index_of, index_nearest,
                                 realimag, remove_dups)
 
-from larch.plugins.xafs import (ETOK, set_xafsGroup, ftwindow,
-                                xftf_fast, find_e0, pre_edge)
-pre_edge = pre_edge.pre_edge
+from larch_plugins.xafs import (ETOK, set_xafsGroup, ftwindow, xftf_fast,
+                                find_e0, pre_edge)
 
 # check for uncertainties package
 HAS_UNCERTAIN = False

--- a/plugins/xafs/autobk.py
+++ b/plugins/xafs/autobk.py
@@ -6,13 +6,13 @@ from larch import Group, Parameter, Minimizer
 from larch import ValidateLarchPlugin, isgroup
 
 # import other plugins from std, math, and xafs modules...
-from larch.plugins.std  import parse_group_args
-from larch.plugins.math import (index_of, index_nearest,
+from larch_plugins.std  import parse_group_args
+from larch_plugins.math import (index_of, index_nearest,
                                 realimag, remove_dups)
 
-from larch.plugins.xafs import (ETOK, set_xafsGroup, ftwindow,
-                                xftf_fast, find_e0, pre_edge)
-pre_edge = pre_edge.pre_edge
+from larch_plugins.xafs import (ETOK, set_xafsGroup, ftwindow, xftf_fast,
+                                find_e0, pre_edge)
+
 
 # check for uncertainties package
 HAS_UNCERTAIN = False

--- a/plugins/xafs/autobk.py
+++ b/plugins/xafs/autobk.py
@@ -6,13 +6,13 @@ from larch import Group, Parameter, Minimizer
 from larch import ValidateLarchPlugin, isgroup
 
 # import other plugins from std, math, and xafs modules...
-from larch_plugins.std  import parse_group_args
-from larch_plugins.math import (index_of, index_nearest,
+from larch.plugins.std  import parse_group_args
+from larch.plugins.math import (index_of, index_nearest,
                                 realimag, remove_dups)
 
-from larch_plugins.xafs import (ETOK, set_xafsGroup, ftwindow, xftf_fast,
-                                find_e0, pre_edge)
-
+from larch.plugins.xafs import (ETOK, set_xafsGroup, ftwindow,
+                                xftf_fast, find_e0, pre_edge)
+pre_edge = pre_edge.pre_edge
 
 # check for uncertainties package
 HAS_UNCERTAIN = False

--- a/plugins/xafs/cauchy_wavelet.py
+++ b/plugins/xafs/cauchy_wavelet.py
@@ -25,9 +25,9 @@
 import numpy as np
 from larch import ValidateLarchPlugin
 
-from larch_plugins.std  import parse_group_args
-from larch_plugins.math import complex_phase
-from larch_plugins.xafs import set_xafsGroup
+from larch.plugins.std  import parse_group_args
+from larch.plugins.math import complex_phase
+from larch.plugins.xafs import set_xafsGroup
 
 @ValidateLarchPlugin
 def cauchy_wavelet(k, chi=None, group=None, kweight=0, rmax_out=10,

--- a/plugins/xafs/cauchy_wavelet.py
+++ b/plugins/xafs/cauchy_wavelet.py
@@ -25,9 +25,9 @@
 import numpy as np
 from larch import ValidateLarchPlugin
 
-from larch.plugins.std  import parse_group_args
-from larch.plugins.math import complex_phase
-from larch.plugins.xafs import set_xafsGroup
+from larch_plugins.std  import parse_group_args
+from larch_plugins.math import complex_phase
+from larch_plugins.xafs import set_xafsGroup
 
 @ValidateLarchPlugin
 def cauchy_wavelet(k, chi=None, group=None, kweight=0, rmax_out=10,

--- a/plugins/xafs/deconvolve.py
+++ b/plugins/xafs/deconvolve.py
@@ -6,10 +6,11 @@ import numpy as np
 from scipy.signal import deconvolve
 from larch import ValidateLarchPlugin
 
-from larch_plugins.std  import parse_group_args
-from larch_plugins.math import (gaussian, lorentzian, _interp,
+from larch.plugins.std  import parse_group_args
+from larch.plugins.xafs import set_xafsGroup
+from larch.plugins.math import (gaussian, lorentzian, _interp,
                                 index_of, index_nearest, remove_dups)
-from larch_plugins.xafs import set_xafsGroup
+
 
 MODNAME = '_xafs'
 

--- a/plugins/xafs/deconvolve.py
+++ b/plugins/xafs/deconvolve.py
@@ -6,11 +6,10 @@ import numpy as np
 from scipy.signal import deconvolve
 from larch import ValidateLarchPlugin
 
-from larch.plugins.std  import parse_group_args
-from larch.plugins.xafs import set_xafsGroup
-from larch.plugins.math import (gaussian, lorentzian, _interp,
+from larch_plugins.std  import parse_group_args
+from larch_plugins.math import (gaussian, lorentzian, _interp,
                                 index_of, index_nearest, remove_dups)
-
+from larch_plugins.xafs import set_xafsGroup
 
 MODNAME = '_xafs'
 

--- a/plugins/xafs/diffkk.py
+++ b/plugins/xafs/diffkk.py
@@ -1,18 +1,19 @@
 
-import time
-import numpy as np
-from scipy.special import erfc
-
 from larch import (Group, Parameter, isParameter, param_value,
                    isNamedClass, Interpreter, Minimizer)
 
-from larch_plugins.std  import show
-from larch_plugins.math import _interp
-from larch_plugins.xray import f1f2, xray_edge, xray_line
-from larch_plugins.xafs import mback
-from larch_plugins.wx   import _newplot, _plot
+from larch.plugins.std  import _show
+from larch.plugins.math import _interp
+from larch.plugins.xray import f1f2, xray_edge, xray_line
+from larch.plugins.xafs import mback
+mback = mback.mback
+import numpy as np
+from scipy.special import erfc
+from math import pi
 
-pi = np.pi
+from larch.plugins.wx.plotter import (_newplot, _plot)
+
+import time
 
 TINY = 1e-20
 FOPI = 4/pi

--- a/plugins/xafs/diffkk.py
+++ b/plugins/xafs/diffkk.py
@@ -1,19 +1,18 @@
 
+import time
+import numpy as np
+from scipy.special import erfc
+
 from larch import (Group, Parameter, isParameter, param_value,
                    isNamedClass, Interpreter, Minimizer)
 
-from larch.plugins.std  import _show
-from larch.plugins.math import _interp
-from larch.plugins.xray import f1f2, xray_edge, xray_line
-from larch.plugins.xafs import mback
-mback = mback.mback
-import numpy as np
-from scipy.special import erfc
-from math import pi
+from larch_plugins.std  import show
+from larch_plugins.math import _interp
+from larch_plugins.xray import f1f2, xray_edge, xray_line
+from larch_plugins.xafs import mback
+from larch_plugins.wx   import _newplot, _plot
 
-from larch.plugins.wx.plotter import (_newplot, _plot)
-
-import time
+pi = np.pi
 
 TINY = 1e-20
 FOPI = 4/pi

--- a/plugins/xafs/estimate_noise.py
+++ b/plugins/xafs/estimate_noise.py
@@ -5,9 +5,9 @@
 from numpy import pi, sqrt, where
 from larch import ValidateLarchPlugin, Group, isgroup
 
-from larch.plugins.math import index_of, realimag
-from larch.plugins.xafs import set_xafsGroup, xftf, xftr
-from larch.plugins.std  import parse_group_args
+from larch_plugins.std  import parse_group_args
+from larch_plugins.math import index_of, realimag
+from larch_plugins.xafs import set_xafsGroup, xftf, xftr
 
 @ValidateLarchPlugin
 def estimate_noise(k, chi=None, group=None, rmin=15.0, rmax=30.0,

--- a/plugins/xafs/estimate_noise.py
+++ b/plugins/xafs/estimate_noise.py
@@ -5,9 +5,9 @@
 from numpy import pi, sqrt, where
 from larch import ValidateLarchPlugin, Group, isgroup
 
-from larch_plugins.std  import parse_group_args
-from larch_plugins.math import index_of, realimag
-from larch_plugins.xafs import set_xafsGroup, xftf, xftr
+from larch.plugins.math import index_of, realimag
+from larch.plugins.xafs import set_xafsGroup, xftf, xftr
+from larch.plugins.std  import parse_group_args
 
 @ValidateLarchPlugin
 def estimate_noise(k, chi=None, group=None, rmin=15.0, rmax=30.0,

--- a/plugins/xafs/feffdat.py
+++ b/plugins/xafs/feffdat.py
@@ -19,8 +19,8 @@ from larch import (Group, Parameter, isParameter,
                    ValidateLarchPlugin,
                    param_value, isNamedClass)
 
-from larch.plugins.xafs import ETOK, set_xafsGroup
-from larch.plugins.xray import atomic_mass, atomic_symbol
+from larch_plugins.xafs import ETOK, set_xafsGroup
+from larch_plugins.xray import atomic_mass, atomic_symbol
 
 SMALL = 1.e-6
 

--- a/plugins/xafs/feffdat.py
+++ b/plugins/xafs/feffdat.py
@@ -19,8 +19,8 @@ from larch import (Group, Parameter, isParameter,
                    ValidateLarchPlugin,
                    param_value, isNamedClass)
 
-from larch_plugins.xafs import ETOK, set_xafsGroup
-from larch_plugins.xray import atomic_mass, atomic_symbol
+from larch.plugins.xafs import ETOK, set_xafsGroup
+from larch.plugins.xray import atomic_mass, atomic_symbol
 
 SMALL = 1.e-6
 

--- a/plugins/xafs/feffit.py
+++ b/plugins/xafs/feffit.py
@@ -12,9 +12,9 @@ from scipy.optimize import leastsq as scipy_leastsq
 from larch import (Group, Parameter, isParameter, Minimizer,
                    ValidateLarchPlugin, isNamedClass)
 
-from larch_plugins.math import index_of, realimag, complex_phase
-from larch_plugins.xafs import (xftf_fast, xftr_fast, ftwindow,
-                                set_xafsGroup, FeffPathGroup, _ff2chi)
+from larch.plugins.math import index_of, realimag, complex_phase
+from larch.plugins.xafs import (xftf_fast, xftr_fast, ftwindow, set_xafsGroup,
+                                FeffPathGroup, _ff2chi)
 
 # use larch's uncertainties package
 from larch.fitting import correlated_values, eval_stderr

--- a/plugins/xafs/feffit.py
+++ b/plugins/xafs/feffit.py
@@ -12,9 +12,9 @@ from scipy.optimize import leastsq as scipy_leastsq
 from larch import (Group, Parameter, isParameter, Minimizer,
                    ValidateLarchPlugin, isNamedClass)
 
-from larch.plugins.math import index_of, realimag, complex_phase
-from larch.plugins.xafs import (xftf_fast, xftr_fast, ftwindow, set_xafsGroup,
-                                FeffPathGroup, _ff2chi)
+from larch_plugins.math import index_of, realimag, complex_phase
+from larch_plugins.xafs import (xftf_fast, xftr_fast, ftwindow,
+                                set_xafsGroup, FeffPathGroup, _ff2chi)
 
 # use larch's uncertainties package
 from larch.fitting import correlated_values, eval_stderr

--- a/plugins/xafs/feffrunner.py
+++ b/plugins/xafs/feffrunner.py
@@ -7,6 +7,7 @@ import subprocess
 
 from larch import (Group, Parameter, isParameter, param_value,
                    isNamedClass, Interpreter)
+from larch.plugins.std import _show
 
 class FeffRunner(Group):
     """
@@ -43,14 +44,14 @@ class FeffRunner(Group):
 
           Other versions of feff in the execution path can also be
           handled, with the caveat that the executable begins with
-          'feff', i.e. 'feff6', 'feff7', etc.
+          "feff', i.e. "feff6", "feff7", etc.
 
             feff = feffrunner(feffinp='path/to/feff6.inp')
             feff.run('feff6')
 
           If the value of the feffinp attribute is a file with a
-          basename other than 'feff.inp', that file will be renamed to
-          'feff.inp' and care will be taken to preserve and existing
+          basename other than "feff.inp", that file will be renamed to
+          "feff.inp" and care will be taken to preserve and existing
           file by that name.
 
     Attributes:

--- a/plugins/xafs/feffrunner.py
+++ b/plugins/xafs/feffrunner.py
@@ -7,7 +7,6 @@ import subprocess
 
 from larch import (Group, Parameter, isParameter, param_value,
                    isNamedClass, Interpreter)
-from larch.plugins.std import _show
 
 class FeffRunner(Group):
     """
@@ -44,14 +43,14 @@ class FeffRunner(Group):
 
           Other versions of feff in the execution path can also be
           handled, with the caveat that the executable begins with
-          "feff', i.e. "feff6", "feff7", etc.
+          'feff', i.e. 'feff6', 'feff7', etc.
 
             feff = feffrunner(feffinp='path/to/feff6.inp')
             feff.run('feff6')
 
           If the value of the feffinp attribute is a file with a
-          basename other than "feff.inp", that file will be renamed to
-          "feff.inp" and care will be taken to preserve and existing
+          basename other than 'feff.inp', that file will be renamed to
+          'feff.inp' and care will be taken to preserve and existing
           file by that name.
 
     Attributes:

--- a/plugins/xafs/fluo.py
+++ b/plugins/xafs/fluo.py
@@ -1,15 +1,16 @@
 import numpy as np
 
 from larch import ValidateLarchPlugin
-from larch_plugins.std import parse_group_args
-from larch_plugins.xray import xray_line, xray_edge, material_mu
-from larch_plugins.xafs import preedge
+from larch.plugins.xray import xray_line, xray_edge
+from larch.plugins.xray import material_mu
+from larch.plugins.xafs import preedge
+from larch.plugins.std import parse_group_args
 
 MODNAME = '_xafs'
 
 @ValidateLarchPlugin
-def fluo_corr(energy, mu, formula, elem, group=None, edge='K', anginp=45,
-              angout=45,  _larch=None, **pre_kws):
+def fluo_oacorr(energy, mu, formula, elem, group=None, edge='K', anginp=45,
+                angout=45,  _larch=None, **pre_kws):
     """correct over-absorption (self-absorption) for fluorescene XAFS
     using the FLUO alogrithm of D. Haskel.
 
@@ -39,7 +40,7 @@ def fluo_corr(energy, mu, formula, elem, group=None, edge='K', anginp=45,
     """
     energy, mu, group = parse_group_args(energy, members=('energy', 'mu'),
                                          defaults=(mu,), group=group,
-                                         fcn_name='fluo_corr')
+                                         fcn_name='fluo_oacorr')
 
     # generate normalized mu for correction
     preinp   = preedge(energy, mu, **pre_kws)
@@ -70,4 +71,4 @@ def fluo_corr(energy, mu, formula, elem, group=None, edge='K', anginp=45,
         group.norm_corr = preout['norm']
 
 def registerLarchPlugin():
-    return (MODNAME, {'fluo_corr': fluo_corr})
+    return (MODNAME, {'fluo_oacorr': fluo_oacorr})

--- a/plugins/xafs/fluo.py
+++ b/plugins/xafs/fluo.py
@@ -1,16 +1,15 @@
 import numpy as np
 
 from larch import ValidateLarchPlugin
-from larch.plugins.xray import xray_line, xray_edge
-from larch.plugins.xray import material_mu
-from larch.plugins.xafs import preedge
-from larch.plugins.std import parse_group_args
+from larch_plugins.std import parse_group_args
+from larch_plugins.xray import xray_line, xray_edge, material_mu
+from larch_plugins.xafs import preedge
 
 MODNAME = '_xafs'
 
 @ValidateLarchPlugin
-def fluo_oacorr(energy, mu, formula, elem, group=None, edge='K', anginp=45,
-                angout=45,  _larch=None, **pre_kws):
+def fluo_corr(energy, mu, formula, elem, group=None, edge='K', anginp=45,
+              angout=45,  _larch=None, **pre_kws):
     """correct over-absorption (self-absorption) for fluorescene XAFS
     using the FLUO alogrithm of D. Haskel.
 
@@ -40,7 +39,7 @@ def fluo_oacorr(energy, mu, formula, elem, group=None, edge='K', anginp=45,
     """
     energy, mu, group = parse_group_args(energy, members=('energy', 'mu'),
                                          defaults=(mu,), group=group,
-                                         fcn_name='fluo_oacorr')
+                                         fcn_name='fluo_corr')
 
     # generate normalized mu for correction
     preinp   = preedge(energy, mu, **pre_kws)
@@ -71,4 +70,4 @@ def fluo_oacorr(energy, mu, formula, elem, group=None, edge='K', anginp=45,
         group.norm_corr = preout['norm']
 
 def registerLarchPlugin():
-    return (MODNAME, {'fluo_oacorr': fluo_oacorr})
+    return (MODNAME, {'fluo_corr': fluo_corr})

--- a/plugins/xafs/mback.py
+++ b/plugins/xafs/mback.py
@@ -1,10 +1,10 @@
 
 from larch import Group, Parameter, isgroup, Minimizer
 
-from larch.plugins.std  import parse_group_args
-from larch.plugins.math import index_of
-from larch.plugins.xray import xray_edge, xray_line, f2_chantler, f1f2
-from larch.plugins.xafs import set_xafsGroup, find_e0
+from larch_plugins.std  import parse_group_args
+from larch_plugins.math import index_of
+from larch_plugins.xray import xray_edge, xray_line, f2_chantler, f1f2
+from larch_plugins.xafs import set_xafsGroup, find_e0
 
 import numpy as np
 from scipy.special import erfc

--- a/plugins/xafs/mback.py
+++ b/plugins/xafs/mback.py
@@ -1,10 +1,10 @@
 
 from larch import Group, Parameter, isgroup, Minimizer
 
-from larch_plugins.std  import parse_group_args
-from larch_plugins.math import index_of
-from larch_plugins.xray import xray_edge, xray_line, f2_chantler, f1f2
-from larch_plugins.xafs import set_xafsGroup, find_e0
+from larch.plugins.std  import parse_group_args
+from larch.plugins.math import index_of
+from larch.plugins.xray import xray_edge, xray_line, f2_chantler, f1f2
+from larch.plugins.xafs import set_xafsGroup, find_e0
 
 import numpy as np
 from scipy.special import erfc

--- a/plugins/xafs/pre_edge.py
+++ b/plugins/xafs/pre_edge.py
@@ -10,10 +10,10 @@ from larch import (Group, Parameter, ValidateLarchPlugin,
                    Minimizer, isgroup)
 
 # now we can reliably import other std and xafs modules...
-from larch.plugins.std import parse_group_args
-from larch.plugins.math import (index_of, index_nearest,
+from larch_plugins.std import parse_group_args
+from larch_plugins.math import (index_of, index_nearest,
                                 remove_dups, remove_nans2)
-from larch.plugins.xafs import set_xafsGroup
+from larch_plugins.xafs import set_xafsGroup
 
 MODNAME = '_xafs'
 MAX_NNORM = 5

--- a/plugins/xafs/pre_edge.py
+++ b/plugins/xafs/pre_edge.py
@@ -10,10 +10,10 @@ from larch import (Group, Parameter, ValidateLarchPlugin,
                    Minimizer, isgroup)
 
 # now we can reliably import other std and xafs modules...
-from larch_plugins.std import parse_group_args
-from larch_plugins.math import (index_of, index_nearest,
+from larch.plugins.std import parse_group_args
+from larch.plugins.math import (index_of, index_nearest,
                                 remove_dups, remove_nans2)
-from larch_plugins.xafs import set_xafsGroup
+from larch.plugins.xafs import set_xafsGroup
 
 MODNAME = '_xafs'
 MAX_NNORM = 5

--- a/plugins/xafs/sigma2_models.py
+++ b/plugins/xafs/sigma2_models.py
@@ -6,7 +6,7 @@ import numpy as np
 from larch import ValidateLarchPlugin
 from larch.larchlib import get_dll
 
-from larch_plugins.xray import atomic_mass
+from larch.plugins.xray import atomic_mass
 import scipy.constants as consts
 # EINS_FACTOR  = hbarc*hbarc/(2 * k_boltz * amu) = 24.254360157751783
 #    k_boltz = 8.6173324e-5  # [eV / K]

--- a/plugins/xafs/sigma2_models.py
+++ b/plugins/xafs/sigma2_models.py
@@ -6,7 +6,7 @@ import numpy as np
 from larch import ValidateLarchPlugin
 from larch.larchlib import get_dll
 
-from larch.plugins.xray import atomic_mass
+from larch_plugins.xray import atomic_mass
 import scipy.constants as consts
 # EINS_FACTOR  = hbarc*hbarc/(2 * k_boltz * amu) = 24.254360157751783
 #    k_boltz = 8.6173324e-5  # [eV / K]

--- a/plugins/xafs/xafsft.py
+++ b/plugins/xafs/xafsft.py
@@ -10,9 +10,10 @@ from scipy.fftpack import fft, ifft
 from scipy.special import i0 as bessel_i0
 
 from larch import ValidateLarchPlugin
-from larch.plugins.math import complex_phase
-from larch.plugins.xafs import set_xafsGroup
-from larch.plugins.std import parse_group_args
+from larch_plugins.std import parse_group_args
+from larch_plugins.math import complex_phase
+from larch_plugins.xafs import set_xafsGroup
+
 
 MODNAME = '_xafs'
 VALID_WINDOWS = ['han', 'fha', 'gau', 'kai', 'par', 'wel', 'sin', 'bes']

--- a/plugins/xafs/xafsft.py
+++ b/plugins/xafs/xafsft.py
@@ -10,9 +10,9 @@ from scipy.fftpack import fft, ifft
 from scipy.special import i0 as bessel_i0
 
 from larch import ValidateLarchPlugin
-from larch.plugins.math import complex_phase
-from larch.plugins.xafs import set_xafsGroup
-from larch.plugins.std import parse_group_args
+from larch_plugins.std import parse_group_args
+from larch_plugins.math import complex_phase
+from larch_plugins.xafs import set_xafsGroup
 
 MODNAME = '_xafs'
 VALID_WINDOWS = ['han', 'fha', 'gau', 'kai', 'par', 'wel', 'sin', 'bes']

--- a/plugins/xafs/xafsft.py
+++ b/plugins/xafs/xafsft.py
@@ -10,9 +10,9 @@ from scipy.fftpack import fft, ifft
 from scipy.special import i0 as bessel_i0
 
 from larch import ValidateLarchPlugin
-from larch_plugins.std import parse_group_args
-from larch_plugins.math import complex_phase
-from larch_plugins.xafs import set_xafsGroup
+from larch.plugins.math import complex_phase
+from larch.plugins.xafs import set_xafsGroup
+from larch.plugins.std import parse_group_args
 
 MODNAME = '_xafs'
 VALID_WINDOWS = ['han', 'fha', 'gau', 'kai', 'par', 'wel', 'sin', 'bes']

--- a/plugins/xray/__init__.py
+++ b/plugins/xray/__init__.py
@@ -1,38 +1,16 @@
+#
+#
+from .chemparser import chemparse
 
-from larch.plugins.xray import physical_constants
+from .physical_constants import (R_ELECTRON_CM, AVOGADRO,
+                                 PLANCK_HC, RAD2DEG)
 
-R_ELECTRON_CM = physical_constants.R_ELECTRON_CM
-AVOGADRO = physical_constants.AVOGADRO
-PLANCK_HC = physical_constants.PLANCK_HC
-RAD2DEG = physical_constants.RAD2DEG
+from .xraydb import xrayDB
 
-from larch.plugins.xray import chemparser
-chemparse = chemparser.chemparse
+from .xraydb_plugin import (atomic_mass, atomic_number, atomic_symbol,
+                            xray_line, xray_lines, xray_edge, xray_edges,
+                            f0, f0_ions, mu_elam, mu_chantler, f1_chantler,
+                            f2_chantler, core_width)
 
-from larch.plugins.xray import xraydb
-
-as_ndarray = xraydb.as_ndarray
-xrayDB     = xraydb.xrayDB
-
-from larch.plugins.xray import xraydb_plugin
-atomic_mass = xraydb_plugin.atomic_mass
-atomic_number = xraydb_plugin.atomic_number
-atomic_symbol = xraydb_plugin.atomic_symbol
-xray_line   = xraydb_plugin.xray_line
-xray_lines  = xraydb_plugin.xray_lines
-xray_edge   = xraydb_plugin.xray_edge
-xray_edges  = xraydb_plugin.xray_edges
-f0          = xraydb_plugin.f0
-f0_ions     = xraydb_plugin.f0_ions
-mu_elam     = xraydb_plugin.mu_elam
-mu_chantler = xraydb_plugin.mu_chantler
-f1_chantler = xraydb_plugin.f1_chantler
-f2_chantler = xraydb_plugin.f2_chantler
-core_width  = xraydb_plugin.core_width
-
-from larch.plugins.xray import materials
-material_mu = materials.material_mu
-material_get = materials.material_get
-
-from larch.plugins.xray import cromer_liberman
-f1f2 = cromer_liberman.f1f2
+from .materials import material_mu, material_get
+from .cromer_liberman import f1f2

--- a/plugins/xray/__init__.py
+++ b/plugins/xray/__init__.py
@@ -2,7 +2,7 @@
 #
 from .chemparser import chemparse
 
-from .physical_constants import (R_ELECTRON_CM, AVOGADRO,
+from .physical_constants import (R_ELECTRON_CM, AVOGADRO, BARN,
                                  PLANCK_HC, RAD2DEG)
 
 from .xraydb import xrayDB
@@ -10,7 +10,7 @@ from .xraydb import xrayDB
 from .xraydb_plugin import (atomic_mass, atomic_number, atomic_symbol,
                             xray_line, xray_lines, xray_edge, xray_edges,
                             f0, f0_ions, mu_elam, mu_chantler, f1_chantler,
-                            f2_chantler, core_width)
+                            f2_chantler, core_width, chantler_data)
 
 from .materials import material_mu, material_get
 from .cromer_liberman import f1f2

--- a/plugins/xray/cromer_liberman.py
+++ b/plugins/xray/cromer_liberman.py
@@ -7,7 +7,8 @@ import larch
 from larch import  ValidateLarchPlugin
 from larch.larchlib import get_dll
 
-from larch.plugins.xray import as_ndarray, core_width, atomic_number
+from ..math.mathutils import as_ndarray
+from .xraydb_plugin import core_width, atomic_number
 
 MODNAME = '_xray'
 CLLIB = None

--- a/plugins/xray/cromer_liberman.py
+++ b/plugins/xray/cromer_liberman.py
@@ -7,8 +7,8 @@ import larch
 from larch import  ValidateLarchPlugin
 from larch.larchlib import get_dll
 
-from ..math.mathutils import as_ndarray
-from .xraydb_plugin import core_width, atomic_number
+from larch_plugins.math import as_ndarray
+from larch_plugins.xray import core_width, atomic_number
 
 MODNAME = '_xray'
 CLLIB = None

--- a/plugins/xray/materials.py
+++ b/plugins/xray/materials.py
@@ -2,7 +2,8 @@ import os
 import numpy as np
 from larch import ValidateLarchPlugin, site_config
 
-from larch.plugins.xray import mu_elam, atomic_mass, chemparse
+from .chemparser import chemparse
+from .xraydb_plugin import mu_elam, atomic_mass
 
 MODNAME = '_xray'
 

--- a/plugins/xray/materials.py
+++ b/plugins/xray/materials.py
@@ -2,8 +2,7 @@ import os
 import numpy as np
 from larch import ValidateLarchPlugin, site_config
 
-from .chemparser import chemparse
-from .xraydb_plugin import mu_elam, atomic_mass
+from larch_plugins.xray import chemparse, mu_elam, atomic_mass
 
 MODNAME = '_xray'
 

--- a/plugins/xray/xraydb.py
+++ b/plugins/xray/xraydb.py
@@ -18,7 +18,9 @@ from sqlalchemy.pool import SingletonThreadPool
 # needed for py2exe?
 import sqlalchemy.dialects.sqlite
 
-def as_ndarray(obj):
+from ..math.mathutils import as_ndarray
+
+def OLDas_ndarray(obj):
     """make sure a float, int, list of floats or ints,
     or tuple of floats or ints, acts as a numpy array
     """
@@ -166,8 +168,8 @@ class xrayDB(object):
             self.session = sessionmaker(bind=self.engine, **kwargs)()
             self.session.flush = readonly_flush
         else:
-            self.session = sessionmaker(bind=self.engine, **kwargs)()            
-            
+            self.session = sessionmaker(bind=self.engine, **kwargs)()
+
         self.metadata =  MetaData(self.engine)
         self.metadata.reflect()
         tables = self.tables = self.metadata.tables
@@ -543,7 +545,7 @@ class xrayDB(object):
             xsec += calc(element, energies, kind='incoh')
 
         return xsec
-    
+
     def coherent_cross_section_elam(self, element, energies):
         """returns coherenet scattering cross section for an element
         at energies (in eV)

--- a/plugins/xray/xraydb.py
+++ b/plugins/xray/xraydb.py
@@ -18,7 +18,7 @@ from sqlalchemy.pool import SingletonThreadPool
 # needed for py2exe?
 import sqlalchemy.dialects.sqlite
 
-from ..math.mathutils import as_ndarray
+from larch_plugins.math import as_ndarray
 
 def OLDas_ndarray(obj):
     """make sure a float, int, list of floats or ints,

--- a/plugins/xray/xraydb_plugin.py
+++ b/plugins/xray/xraydb_plugin.py
@@ -3,9 +3,8 @@ from math import pi
 import larch
 from larch import Group, ValidateLarchPlugin
 
-from .physical_constants import R_ELECTRON_CM, AVOGADRO, PLANCK_HC
-from .xraydb import xrayDB
-from .chemparser import chemparse
+from larch_plugins.xray import (R_ELECTRON_CM, AVOGADRO, PLANCK_HC,
+                                xrayDB, chemparse)
 
 MODNAME = '_xray'
 

--- a/plugins/xray/xraydb_plugin.py
+++ b/plugins/xray/xraydb_plugin.py
@@ -3,8 +3,9 @@ from math import pi
 import larch
 from larch import Group, ValidateLarchPlugin
 
-from larch.plugins.xray import (R_ELECTRON_CM, AVOGADRO, PLANCK_HC,
-                                chemparse, xrayDB)
+from .physical_constants import R_ELECTRON_CM, AVOGADRO, PLANCK_HC
+from .xraydb import xrayDB
+from .chemparser import chemparse
 
 MODNAME = '_xray'
 

--- a/plugins/xrf/__init__.py
+++ b/plugins/xrf/__init__.py
@@ -1,5 +1,5 @@
 from .mca import MCA, isLarchMCAGroup
-from .roi import ROI
+from .roi import ROI, split_roiname
 from .deadtime import calc_icr, correction_factor
 from .xrf_bgr import xrf_background
 from .xrf_calib import xrf_calib_fitrois, xrf_calib_compute, xrf_calib_apply

--- a/plugins/xrf/__init__.py
+++ b/plugins/xrf/__init__.py
@@ -1,0 +1,6 @@
+from .mca import MCA, isLarchMCAGroup
+from .roi import ROI
+from .deadtime import calc_icr, correction_factor
+from .xrf_bgr import xrf_background
+from .xrf_calib import xrf_calib_fitrois, xrf_calib_compute, xrf_calib_apply
+from .xrf_peak import xrf_peak

--- a/plugins/xrf/mca.py
+++ b/plugins/xrf/mca.py
@@ -10,9 +10,8 @@ Authors/Modifications:
 import numpy as np
 from larch import Group, isgroup
 
-from .deadtime import calc_icr, correction_factor
-from roi import ROI
-
+from larch_plugins.xrf.deadtime import calc_icr, correction_factor
+from larch_plugins.xrf.roi import ROI
 
 def isLarchMCAGroup(grp):
     """tests whether variable holds a valid Larch MCAGroup"""

--- a/plugins/xrf/mca.py
+++ b/plugins/xrf/mca.py
@@ -8,9 +8,9 @@ Authors/Modifications:
 * modified and simplified for Larch, M Newville
 """
 import numpy as np
-from larch import Group, isgroup, use_plugin_path
-use_plugin_path('xrf')
-from deadtime import calc_icr, correction_factor
+from larch import Group, isgroup
+
+from .deadtime import calc_icr, correction_factor
 from roi import ROI
 
 
@@ -325,4 +325,3 @@ def create_mca(counts=None, nchans=2048, offset=0, slope=0, quad=0,
 
 def registerLarchPlugin():
     return ('_xrf', {'create_mca': create_mca})
-

--- a/plugins/xrf/xrf_bgr.py
+++ b/plugins/xrf/xrf_bgr.py
@@ -107,9 +107,8 @@ Todo:
 """
 
 import numpy as np
-from larch import use_plugin_path, ValidateLarchPlugin
-use_plugin_path('xrf')
-from mca import isLarchMCAGroup
+from larch import ValidateLarchPlugin
+from .mca import isLarchMCAGroup
 
 REFERENCE_AMPL=100.
 TINY = 1.E-20
@@ -313,4 +312,3 @@ def xrf_background(energy, counts=None, group=None, width=4,
 
 def registerLarchPlugin():
     return ('_xrf', {'xrf_background': xrf_background})
-

--- a/plugins/xrf/xrf_bgr.py
+++ b/plugins/xrf/xrf_bgr.py
@@ -108,7 +108,7 @@ Todo:
 
 import numpy as np
 from larch import ValidateLarchPlugin
-from .mca import isLarchMCAGroup
+from larch_plugins.xrf import isLarchMCAGroup
 
 REFERENCE_AMPL=100.
 TINY = 1.E-20

--- a/plugins/xrf/xrf_calib.py
+++ b/plugins/xrf/xrf_calib.py
@@ -4,24 +4,18 @@ XRF Calibration routines
 """
 
 import numpy as np
-from larch import use_plugin_path, ValidateLarchPlugin
+from larch import ValidateLarchPlugin
 
 try:
     from collections import OrderedDict
 except ImportError:
     from larch.utils import OrderedDict
 
-use_plugin_path('xrf')
-from mca import isLarchMCAGroup
-from roi import split_roiname
+from .mca import isLarchMCAGroup
+from .roi import split_roiname
 
-use_plugin_path('math')
-
-from mathutils import index_of, linregress
-from fitpeak import fit_peak
-
-use_plugin_path('xray')
-from xraydb_plugin import xray_line, xray_lines
+from ..math import index_of, linregress, fit_peak
+from ..xray import xray_line, xray_lines
 
 def xrf_calib_fitrois(mca, _larch=None):
     """initial calibration step for MCA:

--- a/plugins/xrf/xrf_calib.py
+++ b/plugins/xrf/xrf_calib.py
@@ -11,11 +11,11 @@ try:
 except ImportError:
     from larch.utils import OrderedDict
 
-from .mca import isLarchMCAGroup
-from .roi import split_roiname
+from larch_plugins.xrf import isLarchMCAGroup
+from larch_plugins.xrf import split_roiname
 
-from ..math import index_of, linregress, fit_peak
-from ..xray import xray_line, xray_lines
+from larch_plugins.math import index_of, linregress, fit_peak
+from larch_plugins.xray import xray_line, xray_lines
 
 def xrf_calib_fitrois(mca, _larch=None):
     """initial calibration step for MCA:

--- a/plugins/xrf/xrf_peak.py
+++ b/plugins/xrf/xrf_peak.py
@@ -9,15 +9,12 @@ This is a Larch group representing a Peak in an XRF Spectrum.
 
 import numpy as np
 from scipy.interpolate import UnivariateSpline
-from larch import (Group, Parameter, isParameter, ValidateLarchPlugin,
-                   param_value, use_plugin_path, isNamedClass)
+from larch import (Group, Parameter, isParameter,
+                   ValidateLarchPlugin,
+                   param_value, isNamedClass)
 
-use_plugin_path('xray')
-use_plugin_path('math')
-use_plugin_path('xrf')
-
-from xraydb_plugin import xray_line, xray_lines
-from lineshapes import gaussian, lorentzian, voigt, pvoigt
+from ..xray import xray_line, xray_lines
+from ..math import gaussian, lorentzian, voigt, pvoigt
 
 class XRFPeak(Group):
     def __init__(self, name=None, shape='gaussian',
@@ -147,4 +144,3 @@ def xrf_peak(name=None, amplitude=1, sigma=0.1,
 
 def registerLarchPlugin():
     return ('_xrf', {'xrf_peak': xrf_peak})
-

--- a/plugins/xrf/xrf_peak.py
+++ b/plugins/xrf/xrf_peak.py
@@ -13,8 +13,8 @@ from larch import (Group, Parameter, isParameter,
                    ValidateLarchPlugin,
                    param_value, isNamedClass)
 
-from ..xray import xray_line, xray_lines
-from ..math import gaussian, lorentzian, voigt, pvoigt
+from larch_plugins.xray import xray_line, xray_lines
+from larch_plugins.math import gaussian, lorentzian, voigt, pvoigt
 
 class XRFPeak(Group):
     def __init__(self, name=None, shape='gaussian',

--- a/plugins/xrfmap/__init__.py
+++ b/plugins/xrfmap/__init__.py
@@ -1,0 +1,1 @@
+from .xrm_mapfile import read_xrfmap

--- a/plugins/xrfmap/__init__.py
+++ b/plugins/xrfmap/__init__.py
@@ -1,1 +1,8 @@
-from .xrm_mapfile import read_xrfmap
+from .configfile import FastMapConfig
+from .xsp3_hdf5 import read_xsp3_hdf5
+from .xmap_netcdf import read_xmap_netcdf
+from .asciifiles import (readASCII, readMasterFile, readROIFile,
+                        readEnvironFile, parseEnviron)
+from .xrm_mapfile import (read_xrfmap,
+                          GSEXRM_MapFile, GSEXRM_FileStatus,
+                          GSEXRM_Exception, GSEXRM_NotOwner)

--- a/plugins/xrfmap/xrm_mapfile.py
+++ b/plugins/xrfmap/xrm_mapfile.py
@@ -9,14 +9,13 @@ import json
 import larch
 from larch.utils.debugtime import debugtime
 
-from ..io import nativepath, new_filename
-from ..xrf import MCA, ROI
+from larch_plugins.io import nativepath, new_filename
+from larch_plugins.xrf import MCA, ROI
 
-from .configfile import FastMapConfig
-from .xmap_netcdf import read_xmap_netcdf
-from .xsp3_hdf5 import read_xsp3_hdf5
-from .asciifiles import (readASCII, readMasterFile, readROIFile,
-                        readEnvironFile, parseEnviron)
+from larch_plugins.xrfmap import (FastMapConfig, read_xmap_netcdf,
+                                  read_xsp3_hdf5, readASCII,
+                                  readMasterFile, readROIFile,
+                                  readEnvironFile, parseEnviron)
 
 NINIT = 32
 COMPRESSION_LEVEL = 4

--- a/plugins/xrfmap/xrm_mapfile.py
+++ b/plugins/xrfmap/xrm_mapfile.py
@@ -7,25 +7,19 @@ import numpy as np
 import scipy.stats as stats
 import json
 import larch
-from larch import use_plugin_path
 from larch.utils.debugtime import debugtime
 
-use_plugin_path('io')
-use_plugin_path('xrf')
-use_plugin_path('xrfmap')
+from ..io import nativepath, new_filename
+from ..xrf import MCA, ROI
 
-from fileutils import nativepath, new_filename
-from mca import MCA
-from roi import ROI
-
-from configfile import FastMapConfig
-from xmap_netcdf import read_xmap_netcdf
-from xsp3_hdf5 import read_xsp3_hdf5
-from asciifiles import (readASCII, readMasterFile, readROIFile,
+from .configfile import FastMapConfig
+from .xmap_netcdf import read_xmap_netcdf
+from .xsp3_hdf5 import read_xsp3_hdf5
+from .asciifiles import (readASCII, readMasterFile, readROIFile,
                         readEnvironFile, parseEnviron)
 
 NINIT = 32
-COMPRESSION_LEVEL = 4 # compression level
+COMPRESSION_LEVEL = 4
 DEFAULT_ROOTNAME = 'xrfmap'
 
 class GSEXRM_FileStatus:

--- a/plugins/xrfmap/xsp3_hdf5.py
+++ b/plugins/xrfmap/xsp3_hdf5.py
@@ -9,7 +9,7 @@ import h5py
 import sys
 import os
 
-from larch import Group, ValidateLarchPlugin, use_plugin_path
+from larch import Group, ValidateLarchPlugin
 
 # Default tau values for xspress3
 
@@ -75,9 +75,9 @@ def read_xsp3_hdf5(fname, npixels=None, verbose=False,
         dtc_taus = XSPRESS3_TAUS
         if _larch is not None and _larch.symtable.has_symbol('_sys.gsecars.xspress3_taus'):
             dtc_taus = _larch.symtable._sys.gsecars.xspress3_taus
-        
+
     for i in range(ndet):
-        rtime = clocktick * ndattr['CHAN%iSCA0' % (i+1)].value 
+        rtime = clocktick * ndattr['CHAN%iSCA0' % (i+1)].value
         rtime[np.where(rtime<0.1)] = 0.1
         out.realTime[:, i] = rtime
         out.liveTime[:, i] = rtime
@@ -89,7 +89,7 @@ def read_xsp3_hdf5(fname, npixels=None, verbose=False,
             ocr = ocounts/(rtime*1.e-6)
             icr = estimate_icr(ocr, dtc_taus[i], niter=3)
             out.inputCounts[:, i]  = icr * (rtime*1.e-6)
-            
+
 
     h5file.close()
     t2 = time.time()


### PR DESCRIPTION
this is a fairly large change, enabling plugins to be imported from python code as

```python
import larch
from larch_plugins.xafs import pre_edge, autobk, xftf
```

Because so many plugins change, the PR is large out of necessity -- there really is not a smaller unit that can work.

The mechanism here is a bit more fragile than I would actually like.  All tests pass, and applications tested so far run.  I can believe that other, unforeseen errors will arise, and won't merge this until it is better verified.

