### PR TITLE
better handling of colored output 

### DIFF
--- a/lib/interpreter.py
+++ b/lib/interpreter.py
@@ -92,6 +92,7 @@ class Interpreter:
 
     def __init__(self, symtable=None, writer=None, with_plugins=True):
         self.writer = writer or StdWriter()
+        self.writer._larch = self
 
         if symtable is None:
             symtable = SymbolTable(larch=self)

--- a/lib/interpreter.py
+++ b/lib/interpreter.py
@@ -17,7 +17,8 @@ import numpy
 from . import builtins
 from . import site_config
 from .symboltable import SymbolTable, Group, isgroup
-from .larchlib import LarchExceptionHolder, Procedure, ReturnedNone
+from .larchlib import (LarchExceptionHolder, ReturnedNone,
+                       Procedure, StdWriter)
 from .fitting  import isParameter
 from .utils import Closure
 
@@ -90,7 +91,7 @@ class Interpreter:
                        'while')
 
     def __init__(self, symtable=None, writer=None, with_plugins=True):
-        self.writer = writer or sys.stdout
+        self.writer = writer or StdWriter()
 
         if symtable is None:
             symtable = SymbolTable(larch=self)
@@ -142,7 +143,7 @@ class Interpreter:
                 if os.path.isdir(pdir):
                     builtins._addplugin(pdir, _larch=self)
                     loaded_plugins.append(pname)
-                
+
             for pname in sorted(os.listdir(plugins_dir)):
                 if pname not in loaded_plugins:
                     pdir = os.path.join(plugins_dir, pname)

--- a/lib/larchlib.py
+++ b/lib/larchlib.py
@@ -18,6 +18,7 @@ HAS_TERMCOLOR = False
 try:
     from termcolor import colored
     if os.name == 'nt':
+        os.environ.pop('TERM')
         import colorama
         colorama.init()
     HAS_TERMCOLOR = True

--- a/lib/larchlib.py
+++ b/lib/larchlib.py
@@ -202,11 +202,13 @@ class StdWriter(object):
                         'blue', 'magenta', 'cyan', 'white')
 
     termcolor_attrs = ('bold', 'underline', 'blink', 'reverse')
-    def __init__(self, stdout=None, has_color=True):
+    def __init__(self, stdout=None, has_color=True, _larch=None):
         if stdout is None:
             stdout = sys.stdout
         self.has_color = has_color and HAS_TERMCOLOR
         self.writer = stdout
+        self._larch = _larch
+        self.termcolor_opts = None
 
     def _getcolor(self, color=None):
         if self.has_color and color in self.valid_termcolors:
@@ -221,6 +223,21 @@ class StdWriter(object):
         for key, val in kws.items():
             if val and (key in self.termcolor_attrs):
                 attrs.append(key)
+        if self.termcolor_opts is None:
+            try:
+                fcn = self._larch.symtable._builtin.get_termcolor_opts
+                self.termcolor_opts = fcn
+            except:
+                pass
+        if color is None:
+            color_opts = {'color': None}
+            if callable(self.termcolor_opts) and self._larch is not None:
+                color_opts = self.termcolor_opts('text', _larch=self._larch)
+            color = color_opts.pop('color')
+            for key in color_opts.keys():
+                if key in self.termcolor_attrs:
+                    attrs.append('%s' % key)
+
         color = self._getcolor(color)
         if color is not None:
             bkg = self._getcolor(bkg)

--- a/lib/larchlib.py
+++ b/lib/larchlib.py
@@ -14,15 +14,15 @@ from .utils import Closure
 from .symboltable import Group
 from .site_config import larchdir
 
-VALID_ERRORCOLORS = ('grey', 'red', 'green', 'yellow',
-                     'blue', 'magenta', 'cyan', 'white')
-HAS_COLORTERM = False
-
+HAS_TERMCOLOR = False
 try:
     from termcolor import colored
-    HAS_COLORTERM = (os.name != 'nt')
-except:
-    pass
+    if os.name == 'nt':
+        import colorama
+        colorama.init()
+    HAS_TERMCOLOR = True
+except ImportError:
+    HAS_TERMCOLOR = False
 
 class LarchPluginException(Exception):
     """Exception with Larch Plugin"""
@@ -32,7 +32,6 @@ class LarchPluginException(Exception):
 
     def __str__(self):
         return "\n%s" % (self.msg)
-
 
 class Empty:
     def __nonzero__(self): return False
@@ -93,13 +92,7 @@ class LarchExceptionHolder:
         if exc_name in (None, 'None'):
             exc_name = 'UnknownError'
 
-        # print("E>>GET ERROR ", exc_name, e_type, e_val)
-        # print("E>> FNAME :" , self.fname, self.lineno)
-        # print("E>> TB :" , e_tb, len(self.tback))
         out = []
-        #if len(self.tback) > 0:
-        #    out.append(self.tback)
-
         call_expr = None
         call_fname = None
         call_lineno = None
@@ -194,26 +187,70 @@ class LarchExceptionHolder:
             out.append('  %s' % call_expr)
             if call_fname is not None and call_lineno is not None:
                 out.append('file %s, line %i' % (call_fname, call_lineno))
-        if HAS_COLORTERM and getattr(self.symtable._sys, 'color_exceptions', True):
-            color = getattr(self.symtable._sys, 'errortext_color', 'red').lower()
-            if color not in VALID_ERRORCOLORS:
-                color = 'red'
-            attrs = []
-            if getattr(self.symtable._sys, 'errortext_bold', True):
-                attrs.append('bold')
 
-            if getattr(self.symtable._sys, 'errortext_dark', False):
-                attrs.append('dark')
+        return (exc_name, '\n'.join(out))
 
-            if getattr(self.symtable._sys, 'errortext_underline', False):
-                attrs.append('underline')
-            if getattr(self.symtable._sys, 'errortext_blink', False):
-                attrs.append('blink')
-            if getattr(self.symtable._sys, 'errortext_reverse', False):
-                attrs.append('reverse')
-            return (exc_name, colored('\n'.join(out), color, attrs=attrs))
-        else:
-            return (exc_name, '\n'.join(out))
+class StdWriter(object):
+    """Standard writer method for Larch,
+    to be used in place of sys.stdout
+
+    supports methods:
+      write(text, color=None, bkg=None, bold=Fals, reverse=False)
+      flush()
+    """
+    valid_termcolors = ('grey', 'red', 'green', 'yellow',
+                        'blue', 'magenta', 'cyan', 'white')
+
+    termcolor_attrs = ('bold', 'underline', 'blink', 'reverse')
+    def __init__(self, stdout=None, has_color=True):
+        if stdout is None:
+            stdout = sys.stdout
+        self.has_color = has_color and HAS_TERMCOLOR
+        self.writer = stdout
+
+    def _getcolor(self, color=None):
+        if self.has_color and color in self.valid_termcolors:
+            return color
+        return None
+
+    def write(self, text, color=None, bkg=None, **kws):
+        """write text to writer
+        write('hello', color='red', bkg='grey', bold=True, blink=True)
+        """
+        attrs = []
+        for key, val in kws.items():
+            if val and (key in self.termcolor_attrs):
+                attrs.append(key)
+        color = self._getcolor(color)
+        if color is not None:
+            bkg = self._getcolor(bkg)
+            if bkg is not None:
+                bkg= 'on_%s' % bkg
+            text = colored(text, color, on_color=bkg, attrs=attrs)
+        self.writer.write(text)
+
+#
+#         if HAS_TERMCOLOR and getattr(self.symtable._sys, 'color_exceptions', True):
+#             color = getattr(self.symtable._sys, 'errortext_color', 'red').lower()
+#             if color not in VALID_TERMCOLORS:
+#                 color = 'red'
+#             attrs = []
+#             if getattr(self.symtable._sys, 'errortext_bold', True):
+#                 attrs.append('bold')
+#
+#             if getattr(self.symtable._sys, 'errortext_dark', False):
+#                 attrs.append('dark')
+#
+#             if getattr(self.symtable._sys, 'errortext_underline', False):
+#                 attrs.append('underline')
+#             if getattr(self.symtable._sys, 'errortext_blink', False):
+#                 attrs.append('blink')
+#             if getattr(self.symtable._sys, 'errortext_reverse', False):
+#                 attrs.append('reverse')
+#             out = colored('\n'.join(out), color, attrs=attrs))
+
+    def flush(self):
+        self.writer.flush()
 
 
 class Procedure(object):

--- a/lib/larchlib.py
+++ b/lib/larchlib.py
@@ -229,26 +229,6 @@ class StdWriter(object):
             text = colored(text, color, on_color=bkg, attrs=attrs)
         self.writer.write(text)
 
-#
-#         if HAS_TERMCOLOR and getattr(self.symtable._sys, 'color_exceptions', True):
-#             color = getattr(self.symtable._sys, 'errortext_color', 'red').lower()
-#             if color not in VALID_TERMCOLORS:
-#                 color = 'red'
-#             attrs = []
-#             if getattr(self.symtable._sys, 'errortext_bold', True):
-#                 attrs.append('bold')
-#
-#             if getattr(self.symtable._sys, 'errortext_dark', False):
-#                 attrs.append('dark')
-#
-#             if getattr(self.symtable._sys, 'errortext_underline', False):
-#                 attrs.append('underline')
-#             if getattr(self.symtable._sys, 'errortext_blink', False):
-#                 attrs.append('blink')
-#             if getattr(self.symtable._sys, 'errortext_reverse', False):
-#                 attrs.append('reverse')
-#             out = colored('\n'.join(out), color, attrs=attrs))
-
     def flush(self):
         self.writer.flush()
 

--- a/lib/shell.py
+++ b/lib/shell.py
@@ -12,9 +12,7 @@ from .site_config import history_file, show_site_config
 from .version import __version__, __date__
 
 BANNER = """  Larch %s  M. Newville, T. Trainor -- %s
-  using python %s, numpy %s
-"""
-
+  using python %s, numpy %s"""
 
 class shell(cmd.Cmd):
     ps1    = "larch> "
@@ -45,18 +43,15 @@ class shell(cmd.Cmd):
         self.stdout = sys.stdout
 
         if banner_msg is None:
-            banner_msg = BANNER % (__version__, __date__,
-                                   '%i.%i.%i' % sys.version_info[:3],
-                                   numpy.__version__)
-
-
+            banner_msg = 'Larch, Simple Shell'
         self.larch  = Interpreter()
         self.input  = InputText(prompt=self.ps1, _larch=self.larch)
         self.prompt = self.ps1
 
         writer = self.larch.writer
         if not quiet:
-            writer.write("%s\n" % banner_msg, color='blue', bold=True)
+            writer.write(banner_msg, color='red', bold=True)
+            writer.write("\n")
 
         self.larch.run_init_scripts()
         self.termcolor_opts = self.larch.symtable._builtin.get_termcolor_opts

--- a/lib/shell.py
+++ b/lib/shell.py
@@ -6,6 +6,7 @@ import sys
 import numpy
 
 from .interpreter import Interpreter
+from .larchlib import StdWriter
 from .inputText import InputText
 from .site_config import history_file, show_site_config
 from .version import __version__, __date__
@@ -14,15 +15,6 @@ BANNER = """  Larch %s  M. Newville, T. Trainor -- %s
   using python %s, numpy %s
 """
 
-HAS_COLORAMA = False
-try:
-    from termcolor import colored
-    if os.name == 'nt':
-        import colorama
-        colorama.init(convert=True)
-        HAS_COLORAMA = True
-except:
-    pass
 
 class shell(cmd.Cmd):
     ps1    = "larch> "
@@ -57,9 +49,9 @@ class shell(cmd.Cmd):
                                    '%i.%i.%i' % sys.version_info[:3],
                                    numpy.__version__)
 
-        writer = sys.stdout
+        writer = StdWriter()
         if not quiet:
-            writer.write("%s\n" % banner_msg)
+            writer.write("%s\n" % banner_msg, color='blue', bold=True)
 
         self.larch  = Interpreter(writer=writer)
         self.input  = InputText(prompt=self.ps1, _larch=self.larch)

--- a/lib/shell.py
+++ b/lib/shell.py
@@ -49,13 +49,14 @@ class shell(cmd.Cmd):
                                    '%i.%i.%i' % sys.version_info[:3],
                                    numpy.__version__)
 
-        writer = StdWriter()
-        if not quiet:
-            writer.write("%s\n" % banner_msg, color='blue', bold=True)
 
-        self.larch  = Interpreter(writer=writer)
+        self.larch  = Interpreter()
         self.input  = InputText(prompt=self.ps1, _larch=self.larch)
         self.prompt = self.ps1
+
+        writer = self.larch.writer
+        if not quiet:
+            writer.write("%s\n" % banner_msg, color='blue', bold=True)
 
         self.larch.run_init_scripts()
         self.termcolor_opts = self.larch.symtable._builtin.get_termcolor_opts
@@ -151,7 +152,8 @@ class shell(cmd.Cmd):
                     self.prompt = self.ps1
                     break
                 elif ret is not None:
-                    write("%s\n" % repr(ret))
+                    wopts = self.termcolor_opts('text', _larch=self.larch)
+                    write("%s\n" % repr(ret), **wopts)
                 self.prompt = self.ps1
             self.larch.writer.flush()
 

--- a/lib/symboltable.py
+++ b/lib/symboltable.py
@@ -134,7 +134,6 @@ class SymbolTable(Group):
 
     def __init__(self, larch=None):
         Group.__init__(self, name=self.top_group)
-        # self.__writer = writer  or sys.stdout.write
         self._larch = larch
         self._sys = None
         setattr(self, self.top_group, self)

--- a/plugins/std/__init__.py
+++ b/plugins/std/__init__.py
@@ -1,5 +1,3 @@
 #
 from .grouputils import parse_group_args
-from .show import _show as show
-from .show import _get as get
-from .show import group2dict, dict2group, show_tree
+from .show import show, get, group2dict, dict2group, show_tree

--- a/plugins/std/show.py
+++ b/plugins/std/show.py
@@ -179,7 +179,7 @@ def initialize_sys_display(_larch=None):
         symtable.new_group('_sys.display')
     display = symtable._sys.display
 
-    defaults = dict(text='grey', text2='cyan',
+    defaults = dict(text=None, text2='cyan',
                     error='red', comment='green')
     display.colors = Group()
     for key, val in defaults.items():

--- a/plugins/std/show.py
+++ b/plugins/std/show.py
@@ -21,7 +21,7 @@ except:
 TERMCOLOR_COLORS = ('grey', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white')
 
 @ValidateLarchPlugin
-def _get(sym=None, _larch=None, **kws):
+def get(sym=None, _larch=None, **kws):
     """get object from symbol table from symbol name:
 
     >>> g = group(a = 1,  b=2.3, z = 'a string')
@@ -41,56 +41,6 @@ def _get(sym=None, _larch=None, **kws):
         group = symtable._lookup(sym, create=False)
     return group
 
-@ValidateLarchPlugin
-def _show_old(sym=None, _larch=None, with_private=False, **kws):
-    """display group members.
-    Options
-    -------
-    with_private:  show 'private' members ('__private__')
-
-    See Also:  show_tree()
-    """
-    if sym is None:
-        sym = '_main'
-    group = None
-    symtable = _larch.symtable
-    title = sym
-    if symtable.isgroup(sym):
-        group = sym
-        title = repr(sym)[1:-1]
-    elif isinstance(sym, types.ModuleType):
-        group = sym
-        title = sym.__name__
-
-    if group is None:
-        _larch.writer.write("%s\n" % repr(sym))
-        return
-    if title.startswith(symtable.top_group):
-        title = title[6:]
-
-    if group == symtable:
-        title = 'Group _main'
-
-    members = dir(group)
-    out = ['== %s: %i symbols ==' % (title, len(members))]
-    for item in members:
-        if item.startswith('__') and not with_private:
-		#item.endswith('__') and# not with_private):
-            continue
-        obj = getattr(group, item)
-        dval = None
-        if isinstance(obj, numpy.ndarray):
-            if len(obj) > 10 or len(obj.shape)>1:
-                dval = "array<shape=%s, type=%s>" % (repr(obj.shape),
-                                                         repr(obj.dtype))
-        if dval is None:
-            dval = repr(obj)
-        out.append('  %s: %s' % (item, dval))
-#         if not (item.startswith('_Group__') or
-#                 item == '__name__' or item == '_larch' or
-#                 item.startswith('_SymbolTable__')):
-
-    _larch.writer.write("%s\n" % '\n'.join(out))
 
 @ValidateLarchPlugin
 def show_tree(group, _larch=None, indent=0, groups_shown=None, **kws):
@@ -130,7 +80,7 @@ def dict2group(d, _larch=None):
     return Group(**d)
 
 @ValidateLarchPlugin
-def _show(sym=None, _larch=None, with_private=False, with_color=True, 
+def show(sym=None, _larch=None, with_private=False, with_color=True,
           color=None, truncate=True, with_methods=True, **kws):
     """show group members:
     Options
@@ -263,10 +213,9 @@ def initializeLarchPlugin(_larch=None):
 
 
 def registerLarchPlugin():
-    return ('_builtin', {'show': _show,
-                         'get': _get,
+    return ('_builtin', {'show': show,
+                         'get': get,
                          'set_terminal': set_terminal,
                          'group2dict': group2dict,
                          'dict2group': dict2group,
-                         'show_tree': show_tree, 
-                         'show_simple': _show_old})
+                         'show_tree': show_tree})

--- a/plugins/std/show.py
+++ b/plugins/std/show.py
@@ -107,8 +107,8 @@ def show(sym=None, _larch=None, with_private=False, with_color=True,
         title = 'Group _main'
 
     ## set colors for output
-    colopts1 = get_termcolor_opts('foreground', _larch=_larch)
-    colopts2 = get_termcolor_opts('foreground2', _larch=_larch)
+    colopts1 = get_termcolor_opts('text', _larch=_larch)
+    colopts2 = get_termcolor_opts('text2', _larch=_larch)
     if with_color:
         if color is not None:
             colopts1['color'] = color
@@ -153,34 +153,13 @@ def show(sym=None, _larch=None, with_private=False, with_color=True,
         write('  %s: %s\n' % (item, dval), **copts)
     _larch.writer.flush()
 
-
 @ValidateLarchPlugin
-def set_termcolor(style='dark', terminal=None, use_color=True, _larch=None):
-    """configure terminal and termcolor settings
-
-    style
-    use_color
-    terminal
-
-    """
-    style = style.lower()
-    symtable = _larch.symtable
-    display = symtable._sys.display
-    display.use_color = use_color
-    if style == 'dark':
-        display.colors.background = 'black'
-        display.colors.foreground = 'white'
-        display.colors.foreground2 = 'cyan'
-    elif style == 'light':
-        display.colors.background = 'white'
-        display.colors.foreground = 'grey'
-        display.colors.foreground2 = 'cyan'
-    if terminal is not None:
-        display.terminal = terminal
-
-
 def get_termcolor_opts(dtype, _larch=None):
-    """ get color options suitable for color output"""
+    """ get color options suitable for passing to
+    larch's writer.write() for color output
+
+    first argument should be string of
+    'text', 'text2', 'error', 'comment'"""
     out = {'color': None}
     display  = _larch.symtable._sys.display
     if display.use_color:
@@ -200,11 +179,9 @@ def initialize_sys_display(_larch=None):
         symtable.new_group('_sys.display')
     display = symtable._sys.display
 
-    defaults = dict(background='black', foreground='white',
-                    foreground2='cyan', error='red', comment='green')
-
+    defaults = dict(text='grey', text2='cyan',
+                    error='red', comment='green')
     display.colors = Group()
-
     for key, val in defaults.items():
         setattr(display.colors, key, val)
         setattr(display.colors, "%s_attrs" % key, [])
@@ -225,7 +202,6 @@ def registerLarchPlugin():
     return ('_builtin', {'show': show,
                          'get': get,
                          'get_termcolor_opts': get_termcolor_opts,
-                         'set_termcolor': set_termcolor,
                          'group2dict': group2dict,
                          'dict2group': dict2group,
                          'show_tree': show_tree})


### PR DESCRIPTION
starting as a refactoring of the `show()` command that supports alternating colors for output text, this morphed into a rewrite of Larch's stdout() wrapper to now support color, and the dynamic customization of color, for all printed output.    This follows the `termcolor` model for color names and attributes.   

With this PR, one can specify the following variables (with default values):
 
```python
    _sys.display.colors.text  = None #  that is, default color
    _sys.display.colors.text2 = 'cyan'
    _sys.display.colors.comment =  'green'
    _sys.display.colors.error =  'red'
    _sys.display.colors.text_attrs  = []
    _sys.display.colors.text2_attrs = []
    _sys.display.colors.comment_attrs =  []
    _sys.display.colors.error_attrs =  ['bold']  
```

where the color names must be a valid termcolor color name (one of  `'grey', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white'`), and the `_attrs` are lists of valid termcolor text attributes 
`('bold', 'underline', 'blink', 'reverse')`.  Apparently not all combinations of attributes work together  on all types of terminals.

By default, printed text is formatted with the 'text' color and attributes, and exception messages are shown with the `error` color and attributes.  The `show()` command toggles ouput lines between `text` and `text2`.    The `comment` color/attributes is currently unused, but may be useful soon.    The background color (that is, termcolor's `on_red` etc) is not yet fully supported.

One can change these color/attribute settings to alter the colors of the next printed output.  Colored output can be turned off completely by setting `_sys.display.use_color=False`, and turned back on by setting this to `True`.

The `larch.writer.write()` function now takes a 'color'  keyword arg, as well as 'bkg' arg (for `on_*` color), and supports keyword args for text attributes (ie, bold=True, blink=False, etc).  This will allow plugin functions to write multi-colored output.  

Right now, this only works with the command-line, not the wx terminal.  And it needs testing on Windows.


