### PR TITLE
simplify/clarify how to set epsilon_k for a fit (scalar or array)

### DIFF
--- a/examples/feffit/Feffit_01.lar
+++ b/examples/feffit/Feffit_01.lar
@@ -14,8 +14,17 @@ path1 = feffpath('feffcu01.dat',
                  sigma2 = 'ss2',
                  deltar = 'delr')
 
-trans = feffit_transform(kmin=3, kmax=17, kw=2, dk=3, window='hanning', rmin=1.4, rmax=3.0)
-d1    = feffit_dataset(data=cu, pathlist=[path1], transform=trans)
+trans = feffit_transform(kmin=3, kmax=17, kw=2, dk=3, 
+                         window='hanning', rmin=1.4, rmax=3.0)
+
+# to set data uncertainty use either
+#    cu.epsilon_k = 0.003  
+#    cu.epsilon_k = 0.002 + arange(len(cu.k)) * 0.0003
+# so that epsilon_k is a single value or the same length as cu.k.
+# or pass epsilon_k as an argument to feffit_dataset()
+
+d1    = feffit_dataset(data=cu, pathlist=[path1], transform=trans,
+                       epsilon_k=0.003)
 
 out = feffit(fitparams, d1)
 

--- a/plugins/xafs/feffit.py
+++ b/plugins/xafs/feffit.py
@@ -149,7 +149,7 @@ class TransformGroup(Group):
 
 class FeffitDataSet(Group):
     def __init__(self, data=None, pathlist=None, transform=None,
-                 _larch=None, **kws):
+                 epsilon_k=None, _larch=None, **kws):
         self._larch = _larch
         Group.__init__(self, **kws)
 
@@ -159,6 +159,9 @@ class FeffitDataSet(Group):
         if transform is None:
             transform = TransformGroup()
         self.transform = transform
+        if epsilon_k is not None:
+            self.data.epsilon_k = epsilon_k
+
         self.model = Group()
         self.model.k = None
         self.__chi = None
@@ -317,7 +320,8 @@ class FeffitDataSet(Group):
                 xft(p.chi, group=p, rmax_out=rmax_out)
 
 @ValidateLarchPlugin
-def feffit_dataset(data=None, pathlist=None, transform=None, _larch=None):
+def feffit_dataset(data=None, pathlist=None, transform=None,
+                   epsilon_k=None, _larch=None):
     """create a Feffit Dataset group.
 
      Parameters:
@@ -325,6 +329,8 @@ def feffit_dataset(data=None, pathlist=None, transform=None, _larch=None):
       data:      group containing experimental EXAFS (needs arrays 'k' and 'chi').
       pathlist:  list of FeffPath groups, as created from feffpath()
       transform: Feffit Transform group.
+      epsilon_k: Uncertainty in data (either single value or array of
+                 same length as data.k)
 
      Returns:
      ----------


### PR DESCRIPTION
add `epsilon_k` arg to `feffit_dataset()` 

Can be scalar or array (of same length as data.k). 