### PR TITLE
deprecate use of Cromer-Liberman in favor of finer Chantler data

### DIFF
--- a/doc/xray/index.rst
+++ b/doc/xray/index.rst
@@ -291,6 +291,16 @@ line names <xraydb-lines_table>`.  Finally, all energies are in eV.
 
     Note that both f' and f'' are returned here.
 
+.. warning::
+
+   The Cromer-Liberman calculation sometimes generate spurious data,
+   especially at high and low energies.  The data from Chantler's tables
+   should be used in its place.  That is, in almost all places where the
+   Cromer-Liberman values differ from the Chantler values, the
+   Cromer-Liberman data is obviously wrong.
+
+   The Cromer-Liberman tables are kept for historical reasons and backward
+   compatibility, but may be dropped in the future.
 
 
 X-ray Properties of Materials and Chemicals
@@ -444,4 +454,3 @@ and so on are then given.
 
 .. math::
     n = 1 - \delta - i \beta = 1 - \lambda^2 \frac{r_{0}}{2\pi} \sum_j{ n_j  f_j}
-

--- a/plugins/xafs/diffkk.py
+++ b/plugins/xafs/diffkk.py
@@ -8,7 +8,7 @@ from larch import (Group, Parameter, isParameter, param_value,
 
 from larch_plugins.std  import show
 from larch_plugins.math import _interp
-from larch_plugins.xray import f1f2, xray_edge, xray_line
+from larch_plugins.xray import xray_edge, xray_line
 from larch_plugins.xafs import mback
 try:
     from larch_plugins.wx   import _newplot, _plot
@@ -265,7 +265,8 @@ class diffKKGroup(Group):
             Exception("absorption edge not provided for diffKK")
 
         mb_kws = dict(order=3, z=self.z, edge=self.edge, e0=None, emin=None, emax=None,
-                      whiteline=False, leexiang=False, tables='cl', fit_erfc=False, return_f1=True)
+                      whiteline=False, leexiang=False, tables='chantler',
+                      fit_erfc=False, return_f1=True)
         if self.mback_kws is not None:
             mb_kws.update(self.mback_kws)
 

--- a/plugins/xafs/mback.py
+++ b/plugins/xafs/mback.py
@@ -35,7 +35,7 @@ def match_f2(p):
 
 
 def mback(energy, mu, group=None, order=3, z=None, edge='K', e0=None, emin=None, emax=None,
-          whiteline=None, leexiang=False, tables='cl', fit_erfc=False, return_f1=False,
+          whiteline=None, leexiang=False, tables='chantler', fit_erfc=False, return_f1=False,
           _larch=None):
     """
     Match mu(E) data for tabulated f''(E) using the MBACK algorithm and,
@@ -52,7 +52,7 @@ def mback(energy, mu, group=None, order=3, z=None, edge='K', e0=None, emin=None,
       emax:          ending energy for fit
       whiteline:     exclusion zone around white lines
       leexiang:      flag to use the Lee & Xiang extension
-      tables:        'cl' or 'chantler'
+      tables:        'chantler' (default) or 'cl'
       fit_erfc:      True to float parameters of error function
       return_f1:     True to put the f1 array in the group
 
@@ -94,8 +94,8 @@ def mback(energy, mu, group=None, order=3, z=None, edge='K', e0=None, emin=None,
     ### theta is an array used to exclude the regions <emin, >emax, and
     ### around white lines, theta=0.0 in excluded regions, theta=1.0 elsewhere
     (i1, i2) = (0, len(energy)-1)
-    if emin != None: i1 = index_of(energy, emin)
-    if emax != None: i2 = index_of(energy, emax)
+    if emin is not None: i1 = index_of(energy, emin)
+    if emax is not None: i2 = index_of(energy, emax)
     theta = np.ones(len(energy)) # default: 1 throughout
     theta[0:i1]  = 0
     theta[i2:-1] = 0


### PR DESCRIPTION
This deprecates the use of the Cromer-Liberman tables, in preference for using the Chantler tables for f1 and f2., 

It seems that the finer Chantler data now available is more reliable (fewer spurious peaks) than the Cromer-Liberman values.    Since CL is derived from Fortran code, whereas Chantler is pure SQLite + Python, it is also much easier to imagine problems supporting the CL library. 
