### PR TITLE
wxPhoenix and Python3 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 
 python:
     - 2.7
+    - 3.5
 
 before_install:
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ sudo: false
 
 python:
     - 2.7
+    - 3.5
 
 before_install:
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
@@ -15,19 +16,16 @@ before_install:
     - conda update -q conda
     - conda info -a
 
-
 install:
     - conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy scipy h5py dateutil matplotlib pandas nose sphinx
     - source activate test_env
     - conda install wxpython
+    - conda install sqlalchemy
     - pip install termcolor
-    - pip install sqlalchemy 
-    - pip install wxmplot 
+    - pip install wxmplot
     - pip install wxutils
     - python setup.py install
-
 
 script:
     - cd tests
     - nosetests
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ sudo: false
 
 python:
     - 2.7
-    - 3.5
+#     - 3.5
 
 before_install:
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
@@ -19,11 +19,11 @@ before_install:
 install:
     - conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy scipy h5py matplotlib pandas nose sphinx
     - source activate test_env
+    - conda install wxpython
     - conda install sqlalchemy
     - pip install termcolor
-    # - conda install wxpython
-    # - pip install wxmplot
-    # - pip install wxutils
+    - pip install wxmplot
+    - pip install wxutils
     - python setup.py install
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
     - conda info -a
 
 install:
-    - conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy scipy h5py dateutil matplotlib pandas nose sphinx
+    - conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy scipy h5py matplotlib pandas nose sphinx
     - source activate test_env
     - conda install wxpython
     - conda install sqlalchemy

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ sudo: false
 
 python:
     - 2.7
-    - 3.5
 
 before_install:
     - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
@@ -19,11 +18,11 @@ before_install:
 install:
     - conda create -q -n test_env python=$TRAVIS_PYTHON_VERSION numpy scipy h5py matplotlib pandas nose sphinx
     - source activate test_env
-    - conda install wxpython
     - conda install sqlalchemy
     - pip install termcolor
-    - pip install wxmplot
-    - pip install wxutils
+    # - conda install wxpython
+    # - pip install wxmplot
+    # - pip install wxutils
     - python setup.py install
 
 script:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,10 +1,14 @@
-include README.txt LICENSE INSTALL  MANIFEST.in PKG-INFO
-include setup.py publish_docs.sh
-exclude *.pyc core.* *~ *.pdf .deps sandbox
+include README.rst LICENSE INSTALL  MANIFEST.in PKG-INFO
+include setup.py
+exclude *.lar *.pyc core.* *~ *.pdf .deps
 recursive-include lib *.py
 recursive-include tests *.py
 recursive-include doc *
-recursive-exclude doc/_build *
 recursive-include modules *
 recursive-include plugins *
 recursive-include examples *
+recursive-exclude plugins *.pyc
+recursive-exclude plugins __pycache__
+recursive-exclude lib __pycache__
+recursive-exclude doc/_build *
+recursive-exclude sandbox *

--- a/bin/larch
+++ b/bin/larch
@@ -60,12 +60,6 @@ else:
 # can we, and should we, use wx?
 HAS_WX = False
 if not options.nowx:
-    if not hasattr(sys, 'frozen'):
-        try:
-            import wxversion
-            wxversion.ensureMinimal('2.8')
-        except:
-            pass
     try:
         import wx
         HAS_WX = True
@@ -105,16 +99,10 @@ if HAS_WX:
 # execute scripts listed on command-line
 if len(args)>0:
     for arg in args:
+        cmd = "run('%s')" % arg
         if arg.endswith('.py'):
-            shell.default("import %s" %  arg[:-3])
-        else:
-            shell.input.interactive = False
-            finp = open(arg, 'r')
-            for itxt, txt in enumerate(finp.readlines()):
-                shell.input.put(txt[:-1], lineno=itxt, filename=arg)
-            finp.close()
-            shell.larch_execute('')
-            shell.input.interactive = True
+            cmd = "import %s" %  arg[:-3]
+        shell.default(cmd)
 
 # if interactive, start command loop
 if not options.noshell:

--- a/examples/basic/local_namespaces.lar
+++ b/examples/basic/local_namespaces.lar
@@ -1,4 +1,4 @@
-print """
+print("""
 This example shows that a larch function has a
 'local scope' that store symbol names inside the function.
 
@@ -30,13 +30,13 @@ Also note that while inside f1, the module value of 'y' is
 retrieved but that the output of f1() is then assigned to the
 symbol, so that the module-level value of 'y is different
 after running f1().
-"""
+""")
 
 x = 1000.0
 y = sqrt(x)
 
 def f1(a, b, c=1):
-    print  ' inside f1 a,b,c = ', a, b,c 
+    print  ' inside f1 a,b,c = ', a, b,c
     if c < 0:  c = -c
     x = sqrt(a*b*c)
     print ' inside f1 x = ', x
@@ -51,5 +51,3 @@ print '  == call f1 =='
 y = f1(7, 99, c=0.2)
 
 print ' after f1  x , y = ', x, y
-
-

--- a/examples/basic/smoothing.lar
+++ b/examples/basic/smoothing.lar
@@ -3,12 +3,16 @@
 
 npts  = 201
 
-x0    = linspace(0, 10., npts)
-y0    = ones(npts)
+x0  = linspace(0, 10., npts)
+y0  = ones(npts)
 y0[:45] = zeros(45)
 y0[44] = 0.5
 
+s_loren = smooth(x0, y0, 1.0)
+s_gauss = smooth(x0, y0, 1.0, form='gaussian')
+s_voigt = smooth(x0, y0, 1.0, form='voigt')
+
 newplot(x0, y0, label='no smoothing', show_labels=True)
-   plot(x0, smooth(x0, y0, 1.0),                  label='loren, sigma=3')
-   plot(x0, smooth(x0, y0, 1.0, form='gaussian'), label='gauss, sigma=3')
-   plot(x0, smooth(x0, y0, 1.0, form='voigt'),    label='voigt, sigma=3')
+   plot(x0, s_loren, label='loren, sigma=1')
+   plot(x0, s_gauss, label='gauss, sigma=1')
+   plot(x0, s_voigt, label='voigt, sigma=1')

--- a/examples/basic/try.lar
+++ b/examples/basic/try.lar
@@ -1,3 +1,4 @@
+
 x = 1.0
 try:
     y =  7/(x-1)
@@ -12,13 +13,10 @@ except ArithmeticError:
 
 #endtry
 print y
-    
-
 
 print '-----------------'
 
 y = 3
 if y < 100:
-    raise Warning, 'y cannot be less than 100'
-# raise ArithemticError, 'y cannot be less than 100'
+    raise Warning('y cannot be less than 100')
 endif

--- a/examples/basic/use_params.lar
+++ b/examples/basic/use_params.lar
@@ -1,8 +1,6 @@
 
 def g1(amp=1, cen=0, sigma=2):
-    print '=== G1 ' , amp, cen, sigma
-    a = (amp/sigma) * sqrt(log(2.0)/pi)
-    print ' ---> ', a
+    return (amp/sigma) * sqrt(log(2.0)/pi)
 #enddef
 
 amp = param(10, min=1)
@@ -10,8 +8,10 @@ cen = param(5)
 sig = param(0.2)
 
 for i in range(10):
-    amp.value = i * 1.5 
+    amp.value = i * 1.5
     cen.value = 5.0 + (4-i)/2.0
     sig.value = 0.15 + i*i/10.
     g1(amp=amp, cen=cen, sigma=sig)
 #endfor
+
+a = g1(amp=amp, cen=cen, sigma=sig)

--- a/examples/feffit/test_epsk_kws.lar
+++ b/examples/feffit/test_epsk_kws.lar
@@ -14,8 +14,10 @@ test_kweights = (2, 0,  (3, 2, 1))
 test_fitspace = ('k', 'r', 'q')
 
 
-fitparams = group(amp=guess(1), de0=guess(0.1),
-                  ss2=guess(0.002), delr=guess(0.))
+fitparams = group(amp=guess(1.0),
+                  de0=guess(0.1),
+                  ss2=guess(0.002),
+                  delr=guess(0.))
 
 path1 = feffpath('feffcu01.dat', s02 = 'amp', e0 = 'de0',
                  sigma2 = 'ss2', deltar = 'delr')
@@ -27,18 +29,16 @@ out = []
 for eps_k in test_epsk:
     cu.epsilon_k = eps_k
     eps_type = 'float'
-    if isinstance(eps_k, ndarray):
-        eps_type = 'array'
-    elif eps_k is None:
-        del cu.epsilon_k
+    if eps_k is None:
         eps_type = 'None'
+    elif isinstance(eps_k, ndarray):
+        eps_type = 'array'
     #endif
     for kw in test_kweights:
         for fitspace in test_fitspace:
             trans   = feffit_transform(kw=kw, fitspace=fitspace, **trans_args)
             dataset = feffit_dataset(data=cu, pathlist=[path1], transform=trans)
             result  = feffit(fitparams, dataset)
-
             out.append((fitspace, kw, eps_type,
                         fitparams.fit_details.nfev,
                         fitparams.chi_reduced,
@@ -48,8 +48,10 @@ for eps_k in test_epsk:
                         fitparams.de0.value, fitparams.de0.stderr))
         #endfor
     #endfor
+
 #endfor
 
+
 #
-# for i in out: print i
+# for i in out: print(i)
 #

--- a/lib/builtins.py
+++ b/lib/builtins.py
@@ -8,6 +8,8 @@ import time
 import re
 import traceback
 
+import six
+
 from .helper import Helper
 from . import inputText
 from . import site_config
@@ -487,7 +489,7 @@ def _which(sym, _larch=None, **kws):
     stable = _larch.symtable
     if hasattr(sym, '__name__'):
         sym = sym.__name__
-    if isinstance(sym, (str, unicode)) and stable.has_symbol(sym):
+    if isinstance(sym, six.string_types) and stable.has_symbol(sym):
         obj = stable.get_symbol(sym)
         if obj is not None:
             return '%s.%s' % (stable.get_parentpath(sym), sym)
@@ -521,7 +523,7 @@ def _isgroup(obj, *args, **kws):
     if _larch is None:
         raise Warning("cannot run isgroup() -- larch broken?")
     stable = _larch.symtable
-    if isinstance(obj, (str, unicode)) and stable.has_symbol(obj):
+    if isinstance(obj, six.string_types) and stable.has_symbol(obj):
         obj = stable.get_symbol(obj)
     return isgroup(obj, *args)
 

--- a/lib/builtins.py
+++ b/lib/builtins.py
@@ -172,9 +172,6 @@ def _eval(text=None, filename=None, _larch=None, new_module=None):
         _larch.error.append(err)
         symtable._sys.last_error = err
 
-        # expr=text, # "run('%s')" % filename,
-        # exc=IOError, msg=msg)
-
     if new_module is not None:
         # save current module group
         #  create new group, set as moduleGroup and localGroup

--- a/lib/builtins.py
+++ b/lib/builtins.py
@@ -9,6 +9,9 @@ import re
 import traceback
 
 import six
+if six.PY3:
+    import io
+
 
 from .helper import Helper
 from . import inputText
@@ -222,7 +225,11 @@ def _run(filename=None, new_module=None, _larch=None):
         raise Warning("cannot run file '%s' -- larch broken?" % filename)
 
     text = None
-    if isinstance(filename, file):
+    if six.PY2:
+        filetype = file
+    else:
+        filetype = io.IOBase
+    if isinstance(filename, filetype):
         text = filename.read()
         filename = filename.name
     elif os.path.exists(filename) and os.path.isfile(filename):
@@ -272,7 +279,6 @@ def _help(*args, **kws):
     else:
         for a in args:
             helper.help(a)
-
     if helper._larch is not None:
         helper._larch.writer.write("%s\n" % helper.getbuffer())
     else:
@@ -585,4 +591,7 @@ local_funcs = {'_builtin': {'group':_group,
                }
 
 # list of supported valid commands -- don't need parentheses for these
-valid_commands = ('run', 'help')
+valid_commands = ['run', 'help', 'show', 'which']
+
+if six.PY3:
+    valid_commands.append('print')

--- a/lib/builtins.py
+++ b/lib/builtins.py
@@ -165,7 +165,7 @@ def _eval(text=None, filename=None, _larch=None, new_module=None):
             msg = "File '%s' ends with incomplete statement" % (filename)
         while not inp.queue.empty():
             inp.get()
-        err = LarchExceptionHolder(node=None, exc=IOError, msg=msg,
+        err = LarchExceptionHolder(node=None, exc=SyntaxError, msg=msg,
                                    expr=text, fname=filename,
                                    lineno=lineno)
 

--- a/lib/builtins.py
+++ b/lib/builtins.py
@@ -160,12 +160,12 @@ def _eval(text=None, filename=None, _larch=None, new_module=None):
         _larch.raise_exception(None, expr=text, fname=fname, lineno=lineno,
                                exc=SyntaxError, msg= 'input is incomplete')
 
-    if len(inp.delims) > 0 and filename is not None:
-        delim = inp.delims[0]
+    if len(inp.blocks) > 0 and filename is not None:
+        block = inp.block[0]
         while not inp.queue.empty():
             inp.get()
         text, fname, lineno = inp.saved_text
-        msg = "File '%s' ends with un-terminated '%s'" % (filename, delim)
+        msg = "File '%s' ends with un-terminated '%s'" % (filename, block)
         _larch.raise_exception(None, expr="run('%s')" % filename,
                                fname=filename, lineno=lineno,
                                exc=IOError, msg=msg)
@@ -183,7 +183,7 @@ def _eval(text=None, filename=None, _larch=None, new_module=None):
         inp.clear()
         return buffer
 
-    prompt, buffer = inp.run(buffer=buffer)
+    complete, buffer = inp.run(buffer=buffer)
 
     # for a "newly created module" (as on import),
     # the module group is the return value

--- a/lib/builtins.py
+++ b/lib/builtins.py
@@ -154,18 +154,16 @@ def _eval(text=None, filename=None, _larch=None, new_module=None):
     inp = inputText.InputText(_larch=_larch)
     inp.put(text, filename=filename, lineno=0)
     if not inp.complete:
+        msg = "File '%s' ends with incomplete input" % (filename)
+        if len(inp.blocks) > 0 and filename is not None:
+            blocktype, lineno, text = inp.blocks[0]
+            msg = "File '%s' ends with un-terminated '%s'" % (filename,
+                                                              blocktype)
+        elif inp.saved_text is not None:
+            text, fname, lineno = inp.saved_text
+            msg = "File '%s' ends with incomplete statement" % (filename)
         while not inp.queue.empty():
             inp.get()
-        text, fname, lineno = inp.saved_text
-        _larch.raise_exception(None, expr=text, fname=fname, lineno=lineno,
-                               exc=SyntaxError, msg= 'input is incomplete')
-
-    if len(inp.blocks) > 0 and filename is not None:
-        block = inp.block[0]
-        while not inp.queue.empty():
-            inp.get()
-        text, fname, lineno = inp.saved_text
-        msg = "File '%s' ends with un-terminated '%s'" % (filename, block)
         _larch.raise_exception(None, expr="run('%s')" % filename,
                                fname=filename, lineno=lineno,
                                exc=IOError, msg=msg)

--- a/lib/fitting/__init__.py
+++ b/lib/fitting/__init__.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python
+import six
+
 from .parameter import Parameter, isParameter, param_value
 from .minimizer import Minimizer, minimize, fit_report, eval_stderr
 from .confidence import conf_intervals , chisquare_map, conf_report, f_compare
@@ -46,7 +48,7 @@ def chi2_map(minout, xname, yname, nx=11, ny=11, xrange=None,
 
 def param(*args, **kws):
     "create a fitting Parameter as a Variable"
-    if len(args) > 0 and isinstance(args[0], (str, unicode)):
+    if len(args) > 0 and isinstance(args[0], six.string_types):
         expr = args[0]
         args = args[1:]
         kws.update({'expr': expr})
@@ -67,4 +69,3 @@ def guess(value,  **kws):
 def is_param(obj, _larch=None, **kws):
     """return whether an object is a Parameter"""
     return isParameter(obj)
-

--- a/lib/fitting/confidence.py
+++ b/lib/fitting/confidence.py
@@ -46,7 +46,7 @@ def p_trace_to_dict(p_tr, params):
 
 def conf_report(conf_vals):
     out = ['# Confidence Interval Report']
-    names = conf_vals.keys()
+    names = list(conf_vals.keys())
     nvals = len(conf_vals[names[0]])
     maxlen = max([len(i) for i in names])
     if maxlen < 10: maxlen  = 10
@@ -322,5 +322,3 @@ def chisquare_map(minimizer, xname, yname, nx=11, ny=11, xrange=None,
     minimizer.leastsq()
 
     return x_points, y_points, out
-
-

--- a/lib/fitting/uncertainties/__init__.py
+++ b/lib/fitting/uncertainties/__init__.py
@@ -233,6 +233,7 @@ import math
 from math import sqrt, log  # Optimization: no attribute look-up
 import copy
 import warnings
+import six
 
 # Numerical version:
 __version_info__ = (1, 9)
@@ -1637,7 +1638,7 @@ def ufloat(representation, tag=None):
     # from being considered as tags, here:
     if tag is not None:
         #! 'unicode' is removed in Python3:
-        assert isinstance(tag, (str, unicode)), "The tag can only be a string."
+        assert isinstance(tag, six.string_types), "The tag can only be a string."
 
     #! The special ** syntax is for Python 2.5 and before (Python 2.6+
     # understands tag=tag):

--- a/lib/fitting/uncertainties/__init__.py
+++ b/lib/fitting/uncertainties/__init__.py
@@ -1167,7 +1167,6 @@ def add_operators_to_AffineScalarFunc():
     """
     Adds many operators (__add__, etc.) to the AffineScalarFunc class.
     """
-
     ########################################
 
     #! Derivatives are set to return floats.  For one thing,
@@ -1224,10 +1223,7 @@ def add_operators_to_AffineScalarFunc():
     # behavior of float(1j) is similar.
     for coercion_type in ('complex', 'int', 'long', 'float'):
         def raise_error(self):
-            raise TypeError("can't convert an affine function (%s)"
-                            ' to %s; use x.nominal_value'
-                            # In case AffineScalarFunc is sub-classed:
-                            % (self.__class__, coercion_type))
+            raise TypeError("cannot convert an affine function to %s; use x.nominal_value" % (coercion_type))
 
         setattr(AffineScalarFunc, '__%s__' % coercion_type, raise_error)
 
@@ -1629,7 +1625,7 @@ def ufloat(representation, tag=None):
     # thus does not have any overhead.
 
     #! Different, in Python 3:
-    if isinstance(representation, basestring):
+    if isinstance(representation, six.string_types):
         representation = str_to_number_with_uncert(representation)
 
     #! The tag is forced to be a string, so that the user does not

--- a/lib/helpTopics.py
+++ b/lib/helpTopics.py
@@ -5,17 +5,17 @@ The data here contain python variable holding text that
 are used as principle help topics.
 
 M. Newville Univ of Chicago, T. Trainor, Univ of Alaska Fairbanks (2005,2006)
- 
+
 """
 ##
 ## usage notes:
 ##    to add a new top level help topic, simply create a variable named '_h_%s' % topic
 ## where 'topic' is a unique (case-insensitive!) name for a help topic.
 ##
-## when  help(topic)  
+## when  help(topic)
 ##
 _h_Shell = """Larch command-line shell help:
-  
+
 """
 
 _h_Help =  """
@@ -30,12 +30,12 @@ _h_Help =  """
 _h_Overview = """
 This is Larch (Matt Newville and Tom Trainor 2009).
 
-Larch is a data processing language designed to be 
+Larch is a data processing language designed to be
   - easy to use for novices.
   - complete enough for intermediate to advanced data processing.
   - data-centric, so that arrays of data are easy to manage and use.
   - easily extendable with python.
- 
+
 Larch uses Numeric Python and SciPy for all its numerical functionality,
 so that processing data in arrays is both easy and fast. There is a wide
 range of 'advanced numeric capabilities' for Larch, including complex
@@ -45,7 +45,7 @@ Larch Features:
 
 ==Simple Syntax:
   Variable and function names are simple, undecorated strings.  The
-  syntax is deliberately close to Python, so that 
+  syntax is deliberately close to Python, so that
 
 ==Data Types:
 
@@ -57,8 +57,8 @@ Larch Features:
   more complicated "slices":
         larch> x   = 1             # int
         larch> y   = 7 + 2j        # complex number:  real + imag'j'
-        larch> arr = arange(10)    # simple array 
-        larch> print arr 
+        larch> arr = arange(10)    # simple array
+        larch> print arr
             [0 1 2 3 4 5 6 7 8 9 10]
         larch> print arr[3]
             3
@@ -79,18 +79,18 @@ Larch Features:
   Each variable and function lives in Group, which can be nested much
   like a file directory structure -- Group.Subgroup.Variable.  These is
   no limit on the number of subgroups, within a group or the level of
-  nesting of groups.  This allows you to organize data,  
+  nesting of groups.  This allows you to organize data,
      print DataSet1.Energy
      print DataSet2.Energy
 
   and so on. To access a variable, you can always use the Full name:
      print Group1.SubgroupA.Variable
-     
+
   If you ask for a name that is NOT a Full name, larch tries to look it up.
 
   It does this by always having a "local group" which is always looked in first.
-  If 
-  
+  If
+
   Unqualified names (ie, a name without a 'group.' prefix) will use a default
   order to determine which Group to associate with a name:  There is always
   a "Default Data Group" and a "Default Function Group" each of which can be
@@ -98,19 +98,19 @@ Larch Features:
   "_builtin", which contains many built in functions and constants (sin and pi,
   for example), and "_main".  At startup, "_main" is empty, and is set as the
   "Default Data Group" and "Default Function Group".
-  
+
   When creating or assigning a variable without an explicit group name, the default
   Data Group is used.  When creating or assigning a procedure without an explicit
   group name, the default Function Group is used.
-  
+
   When using (say, on the right-hand side of a statement) a variable or function with
   an unqualified group name, the first matching name in the list
-     (Default Data Group, Default Function Group, "_main", "_builtin") 
+     (Default Data Group, Default Function Group, "_main", "_builtin")
 
   is used.  The Default Data Group can be changed with
         larch> datagroup('mydata')
 
-  and the Default Function Group can be changed with 
+  and the Default Function Group can be changed with
         larch> funcgroup('myfuncs')
 
   Assigning a fully qualified variable or function to a group that previously did
@@ -129,9 +129,9 @@ Larch Features:
             Default Function Group = _main
             All Groups:
                 _main  _builtin  group1
-  
+
 ==Functions and Commands.  Functions and commands have similiar name structure as
-  data (group.func,group.cmd). 
+  data (group.func,group.cmd).
   The default group name for functions and commands is _main (functions and commands with
   this group name do not need full name qualification).
   Eg. you can also assign variables variable values with setvar() function:
@@ -140,7 +140,7 @@ Larch Features:
 
   The potential advantage here is that 'v' and 'group1' are string types,
   not literal variable names, so they can be computed or passed in a
-  procedure. 
+  procedure.
 
 ==Clean syntax for programming:
   The syntax is "Python Inspired", with some notable exceptions.  Most
@@ -149,16 +149,16 @@ Larch Features:
 
         for i in range(10):
             print i
-        endfor     
+        endfor
 
   There are also while blocks and if-elif-else blocks:
         n = 0
-        while n<10: 
+        while n<10:
            print ' n = ',n
            if n==3: print 'here is 3!!'
                n = n + 1
            endwhile
-     
+
         if n > 10:
             print 'No'
         elif n > 5 and n < 8:
@@ -176,7 +176,7 @@ Larch Features:
              'documentation string'
               print 'this is my funcition ', arg1
               print 'optional param = ', option
-              if type(option) != 'string':     
+              if type(option) != 'string':
                   print 'option must be a string!!'
                   return False
               endif
@@ -185,7 +185,7 @@ Larch Features:
               return value > 10.
         enddef
 
-  which could be called as 
+  which could be called as
         larch> ret = myfunc(3., option = 'xx')
         larch> print ret, x.tmp
           False 1.73205080757
@@ -198,7 +198,7 @@ Larch Features:
   you can construct a larch expression on the fly from strings and execute it:
 
         larch> eval("%s.value = %f" %  ['group', 10.2])
-        larch> print group.value 
+        larch> print group.value
           10.2
 
 ==read_ascii() function:
@@ -206,7 +206,7 @@ Larch Features:
 
         larch> read_ascii('my.dat', group='f')
           ['f', 'x', ''y']
-      
+
   this read 2 columns (labeled 'x' and 'y') from the column file and
   created the array variables f.x and f.y.  Also created was f.titles
   to hold the titles in the data file (non-numeric content at the top of
@@ -215,17 +215,17 @@ Larch Features:
 ==On-line help:
   well, this is in progress....
 
-==Easy to add your python functions, including getting access to all  
+==Easy to add your python functions, including getting access to all
   the 'data groups' inside your python function.
 
 ==Differences between larch and Python (for python users):
-  -  larch has many builtins and assumes Numerical data. 
+  -  larch has many builtins and assumes Numerical data.
   -  larch has no tuples. Lists are used in their place.
-  -  indentation does not matter. blocks are ended with 'end***' 
+  -  indentation does not matter. blocks are ended with 'end***'
      (if / endif , for /endfor, def/enddef)
   -  when in doubt, assignment makes a copy, and does not give a reference
   -  data types are NOT objects, and so have no methods.  You must use
-     procedural approaches 
+     procedural approaches
        x = arange(100)
        reshape(x,[10,10])   instead of x.shape = (10,10)
 """
@@ -253,15 +253,15 @@ _h_Strings = """
       \\"   literal "
       \\'   literal '
       \\\   the backslach character itself.
-      
+
   You can escape quote characters ('\\"' or '\\'') so that they do not mark the end of a
-  string sequence: 
+  string sequence:
       larch> x = 'a string\\'s string'
       larch> y = "\\"a string with a double quote\\", he said."
 
- 
+
   ==Multi-line Strings with Triple Quotes
-   
+
   Larch allows multi-line strings (that is strings that span lines).  One simple way to do this is
   to include a newline character ('\\n') character in the string, but this is not always sufficient.
   Another way is to use triple quotes (three quotes in a row: either ''' or  \"\"\") to enclose the
@@ -285,28 +285,28 @@ _h_Strings = """
   This is done by putting format codes in a string and supplying values to fill in.  Format
   codes use the '%' character to mark the formatting to do.
 
-  Following normal conventions, a formatted string for a floating point number might look like this: 
+  Following normal conventions, a formatted string for a floating point number might look like this:
 
       larch> print "x = %8.4f" % sqrt(12)
       x =   3.4641
-      
+
   The "%8.4f" tells the formatting to format a floating point number (the 'f') with 8 total numbers
   and 4 numbers after the decimal point.   A plain '%' is used to separate the format string and the
   value(s) to format.  Other format codes:
 
       ......
-  
+
   ==Using a dictionary for string formatting
 
     Borrowing from Python, larch also allow you to format a string using a dictionary instead of a
     simple list.  This can be a big advantage when formatting many values or formatting data from
     complicated data structures.  In this method, you explicitly set the dictionary key to use by
     naming them between the '%' and the format code:
-    
+
       larch> data  = {'name':'File 1', 'date':'Monday, April 3, 2006', 'x': 12.4}
       larch> print " %(name)s , x = %(x)f" % data
       File 1 , x = 12.4
-     
+
 """
 
 # dictionaries
@@ -324,7 +324,7 @@ _h_Arrays = """
 # lists
 _h_Lists = """
   Working with lists:
-  
+
 """
 
 # data types
@@ -354,7 +354,7 @@ _h_Control = """
    of code) to be run as a group.  This allows the block of code to be run
    only under some conditions, or to be run repeatedly with different values
    for some variables in the block.
-   
+
    The syntax of larch uses a colon ':' and a small number of keywords to define
    the blocks of code:
        if x==0:
@@ -362,7 +362,7 @@ _h_Control = """
        else:
           x = 2 /x
        endif
-   
+
 
  = If statements:
 
@@ -391,28 +391,28 @@ _h_Control = """
    the case in larch: the entire statement may be evaluated.
 
    The second version uses the same 'if condition:', but on a line by itself, followed
-   by  multiple statements.  This version ends with 'endif' to indicate how far the 
+   by  multiple statements.  This version ends with 'endif' to indicate how far the
    block of code extends:
        if x < 0  :
            x = -x
-           print ' x set to ',x 
+           print ' x set to ',x
        endif
 
    Next, there's the 'if-else-endif' version which runs either one block or the
-   other, and looks like this (note the 
+   other, and looks like this (note the
        if x<0:
            x = -x
-           print ' x set to ',x 
+           print ' x set to ',x
        else:
            print ' x was positive to begin with'
        endif
 
    The final and most complete variation uses 'elif' (pronounced "else if") to allow
    multiple conditions to be tested:
-   
+
        if x<0:
            x = -x
-           print ' x set to ',x 
+           print ' x set to ',x
        elif x>10:
            x = 10
            print ' x was too big, set to ', x
@@ -433,7 +433,7 @@ _h_Control = """
    the loop.  Usually, a for loop runs a predictable number of times (see the
    section below on Break and Continue for when it does not!). A for loop
    looks like:
-    
+
        for i in [1,2,3]:
            print i, i*i
        endfor
@@ -450,9 +450,9 @@ _h_Control = """
    list.
 
    There is also a 'one-line' version of the for loop:
-  
+
        for i in [1,2,3]: call_some_function(i)
-   
+
 
  = While loops:
 
@@ -472,12 +472,12 @@ _h_Control = """
 
    Beware that a while loop makes it easy to make an "infinite loop" (for example, if
    the value of x had not been increased in the block).
-   
+
  = Break and Continue in For and While loops
 
    In both for loops and while loops, the block can be exited with a 'break' statement.
-   
-   
+
+
  = Try / Except blocks:
 
    Sometimes error happen, and it is desirable to run some block of code
@@ -498,8 +498,6 @@ _h_Try = ""
 _h_Builtin = ""
 _h_Functions = ""
 _h_Procedures = ""
-_h_DefVariables = 'Defined Variables'
-
 _h_String_Formatting = "String Formatting"
 
 def generate():
@@ -514,7 +512,7 @@ def generate():
 
     topnames = sorted(topics.keys())
     nx= 2 + sorted([len(i) for i in topnames])[-1]
-    
+
     fmt = "%%%i.%is" % (nx,nx)
     for t in topnames:
         s = "%s %s" % (s,fmt%(t+(' '*nx)))

--- a/lib/helper.py
+++ b/lib/helper.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 main = """This is Larch main help"""
 
+import six
+
 from . import helpTopics
 Help_topics = helpTopics.generate()
 
@@ -21,14 +23,14 @@ class Helper(object):
         for arg in args:
             if arg is None:
                 continue
-            if isinstance(arg, (str, unicode)) and str(arg) in Help_topics:
+            if isinstance(arg, six.string_types) and str(arg) in Help_topics:
                 self.addtext(Help_topics[arg])
             else:
                 self.show_symbol(arg)
 
     def show_symbol(self, arg):
         "show help for a symbol in the symbol table"
-        if isinstance(arg, (str, unicode)):
+        if isinstance(arg, six.string_types):
             sym = self._larch.symtable.get_symbol(arg, create=False)
             out = None
         else:

--- a/lib/helper.py
+++ b/lib/helper.py
@@ -24,6 +24,7 @@ class Helper(object):
             if arg is None:
                 continue
             if isinstance(arg, six.string_types) and str(arg) in Help_topics:
+                print(' -- TOPICAL HELP ', arg)
                 self.addtext(Help_topics[arg])
             else:
                 self.show_symbol(arg)
@@ -32,25 +33,25 @@ class Helper(object):
         "show help for a symbol in the symbol table"
         if isinstance(arg, six.string_types):
             sym = self._larch.symtable.get_symbol(arg, create=False)
-            out = None
         else:
-            out = sym = arg
+            sym = arg
 
         if sym is None:
             self.addtext(" '%s' not found"  % (arg))
-        atype = str(type(sym))
-        atype = atype.replace('type ','').replace('class ','').replace("'",'')
-        atype = self.TypeNames.get(atype, atype)
 
-        if out is None:
-            out = repr(sym)
-            if hasattr(sym, '__call__') and sym.__doc__ is not None:
+        else:
+            atype = str(type(sym))
+            atype = atype.replace('type ','').replace('class ','').replace("'",'')
+            atype = self.TypeNames.get(atype, atype)
+
+            if atype in ('<tuple>', '<list>', '<dict>', '<array>'):
+                out = "%s %s" % (out, atype)
+            elif hasattr(sym, '__call__') and sym.__doc__ is not None:
+                self.addtext(repr(sym))
                 out = sym.__doc__
-
-        if atype in ('<tuple>','<list>','<dict>','<array>'):
-            out = "%s %s" % (out,atype)
+            else:
+                out = repr(sym)
         self.addtext("  %s" % out)
-
 
     def addtext(self,text):
         self.buff.append(text)

--- a/lib/inputText.py
+++ b/lib/inputText.py
@@ -1,504 +1,218 @@
 #!/usr/bin/env python
-"""
-handle input Text for Larch -- inclides translation to Python text
-"""
+#
+# InputText for  Larch
+
 from __future__ import print_function
-from six.moves import input
-from .utils import isValidName, isNumber, isLiteralStr, find_delims
 
-def strip_comments(sinp, char='#'):
-    "find character in a string, skipping over quoted text"
-    if sinp.find(char) < 0:
-        return sinp
-    i = 0
-    while i < len(sinp):
-        tchar = sinp[i]
-        if tchar in ('"',"'"):
-            eoc = sinp[i+1:].find(tchar)
-            if eoc > 0:
-                i = i + eoc
-        elif tchar == char:
-            return sinp[:i].rstrip()
-        i = i + 1
-    return sinp
+from six.moves import queue
 
-
-OPENS, CLOSES, QUOTES, BSLASH, COMMENT = '{([', '})]', '\'"', '\\', '#'
+OPENS  = '{(['
+CLOSES = '})]'
 PARENS = dict(zip(OPENS, CLOSES))
-
+QUOTES = '\'"'
+BSLASH = '\\'
+COMMENT = '#'
 DBSLASH = "%s%s" % (BSLASH, BSLASH)
 
-def line_complete(txt):
-    """returns whether single line of text is a complete:
-    completeness here means the text (one line only!)
-    contains completed quotes, and parens, braces, brackets
-    are matched (including nesting) and the text does not
-    end with a backslash.
+BLOCK_FRIENDS = {'if':    ('else', 'elif'),
+                 'for':   ('else',),
+                 'def':   (),
+                 'try':   ('else', 'except', 'finally'),
+                 'while': ('else',),
+                 None: ()}
+
+STARTKEYS = ['if', 'for', 'def', 'try', 'while']
+
+def find_eostring(txt, eos, istart):
+    """find end of string token for a string"""
+    while True:
+        inext = txt[istart:].find(eos)
+        if inext < 0:  # reached end of text before match found
+            return eos, len(txt)
+        elif (txt[istart+inext-1] == BSLASH and
+              txt[istart+inext-2] != BSLASH):  # matched quote was escaped
+            istart = istart+inext+len(eos)
+        else: # real match found! skip ahead in string
+            return '', istart+inext+len(eos)-1
+
+def is_complete(text):
+    """returns whether a text of code is complete
+    for strings quotes and open / close delimiters,
+    including nested delimeters.
     """
-
-    lines = txt.split('\n')
-    if len(lines) > 1 or txt.rstrip().endswith(BSLASH):
-        return False
-
-    def find_eostring(txt, eos, istart):
-        while True:
-            inext = txt[istart:].find(eos)
-            if inext < 0:  # reached end of text before match found
-                return eos, len(txt)
-            elif (txt[istart+inext-1] == BSLASH and
-                  txt[istart+inext-2] != BSLASH):  # matched quote was escaped
-                istart = istart+inext+len(eos)
-            else: # real match found! skip ahead in string
-                return '', istart+inext+len(eos)-1
-
-
-    eos, i = '', 0
+    itok = istart = 0
+    eos = ''
     delims = []
-    while i < len(txt):
-        c = txt[i]
+    while itok < len(text):
+        c = text[itok]
         if c in QUOTES:
             eos = c
-            if txt[i:i+3] == c*3:
+            if text[itok:itok+3] == c*3:
                 eos = c*3
-            istart = i + len(eos)
-            eos, i = find_eostring(txt, eos, istart)
+            istart = itok + len(eos)
+            # leap ahead to matching quote, ignoring text within
+            eos, itok = find_eostring(text, eos, istart)
         elif c in OPENS:
             delims.append(PARENS[c])
-        elif c in CLOSES and len(delims)>0 and c == delims[-1]:
+        elif c in CLOSES and len(delims) > 0 and c == delims[-1]:
             delims.pop()
         elif c == COMMENT and eos == '': # comment char outside string
-            i = len(txt)
-        i += 1
+            itok = len(text)
+        itok += 1
+    return eos=='' and len(delims)==0 and not text.rstrip().endswith(BSLASH)
 
-    return (eos == '' and len(delims) == 0)
+def strip_comments(text, char='#'):
+    """return text with end-of-line comments removed"""
+    out = []
+    for line in text.split('\n'):
+        if line.find(char) > 0:
+            i = 0
+            while i < len(line):
+                tchar = line[i]
+                if tchar == char:
+                    line = line[:i]
+                    break
+                elif tchar in ('"',"'"):
+                    eos = line[i+1:].find(tchar)
+                    if eos > 0:
+                        i = i + eos
+                i += 1
+        out.append(line.rstrip())
+    return '\n'.join(out)
 
+def get_key(text):
+    """return keyword: first word of text,
+    isolating keywords followed by '(' and ':' """
+    t =  text.replace('(', ' (').replace(':', ' :').strip()
+    return t.split(' ', 1)[0].strip()
+
+def block_start(text):
+    """return whether a complete-extended-line of text
+    starts with a block-starting keyword, one of
+    ('if', 'for', 'try', 'while', 'def')
+    """
+    txt = strip_comments(text)
+    key = get_key(txt)
+    if key in STARTKEYS and txt.endswith(':'):
+        return key
+    return False
+
+def block_end(text):
+    """return whether a complete-extended-line of text
+    starts wih block-ending keyword,
+    '#end' + ('if', 'for', 'try', 'while', 'def')
+    """
+    txt = text.strip()
+    if txt.startswith('#end') or txt.startswith('end'):
+        n = 3
+        if txt.startswith('#end'):
+            n = 4
+        key = txt[n:].split(' ', 1)[0].strip()
+        if key in STARTKEYS:
+            return key
+    return False
+
+BLANK_TEXT = ('', '<incomplete input>', -1)
 
 class InputText:
-    """Input Larch Code:  handles loading and reading code text, and
-    providing blocks of compile-able python code to be converted to AST.
-
-    InputText accepts and stores single or multiple lines of input text,
-
-    including as from an interactive prompt, watching for blocks of code,
-    and keeping track of whether a block are complete.
-
-    When asked for the next block of code, it emits blocks of valid
-    (hopefully!) python code ready to parsed by 'ast.parse'
-
-    Uses a FIFO (First In, First Out) buffer to allow mixing of input/output.
-    Can read from a specified input source for 'interactive' mode
-
-    usage:
-
-    >>> text = InputText()
-    >>> s = 'a statement'
-    >>> text.put(s)   # add lines of text
-    >>> text.get(s)   # get complete code block, ready for Compiler.eval
-
-
-    the following translations are made from valid Larch to valid Python:
-
-    1. Block Indentation:
-        larch blocks may end with one of the tokens:
-            ('end', 'endXXX', '#end', '#endXXX')
-        for an 'XXX' block (one of 'if', 'for', 'while', 'try', and 'def')
-        where the token starts a line of text, followed by whitespace or
-        a comment starting with a '#'.
-
-    2. Command Syntax:
-        larch allows lines of code which execute a function without return
-        value to be viewed as "commands" and written without parentheses,
-        so that the function call
-             function(x, y)
-        can be written as
-             function x, y
-
-        Note that 'function' must be in _sys.valid_commands for this to work.
-
-    3. Print:
-        as a special case of rule 3, and because Python is going through
-        changes in the syntax of "print", print statements are translated
-        from either "print(list)" or "print list" to
-             _builtin._print(list)
-
-    """
-    indent = ' '*4
-    ps1 = ' >'
-    ps2 = '....>'
-    block_friends = {'if':    ('else', 'elif'),
-                     'for':   ('else',),
-                     'def':   (),
-                     'try':   ('else', 'except', 'finally'),
-                     'while': ('else',) }
-
-    nonkey = 'NONKEY'
-    empty_frame = (None, None, -1)
-
-    def __init__(self, prompt=None, interactive=True, input=None,
-                 filename=None, _larch=None):
-        if prompt is not None:
-            self.ps1 = prompt
-        self.input = None
-        self._larch = _larch
-        self.interactive = interactive
+    """input text for larch"""
+    def __init__(self, _larch=None, **kws):
+        self.queue = queue.Queue()
+        self.filename = '<stdin>'
         self.lineno = 0
-        self.filename = filename or '<stdin>'
-        if interactive:
-            self.input = input or self.__defaultInput
-        self.clear()
+        self.curline = 0
+        self.curtext = ''
+        self.delims = []
+        self._larch = _larch
+        self.valid_cmds = ('print', 'run', 'show', 'help')
+        self.saved_text = BLANK_TEXT
 
-    def readfile(self, fname):
-        fh = open(fname, 'r')
-        self.put(fh.read(), filename=fname, lineno=0)
-        fh.close()
-
-    def put(self, text, filename=None, lineno=None):
-        """add line of input code text"""
-        self.fname = filename or self.filename or '<stdin>'
-        if lineno is not None:
-            self.lineno = lineno
-
-        def addTextInput(txt):
-            complete = self.__isComplete(txt)
-            if complete:
-                self.eos = ""
-                self.delims = []
-
-            self.input_buff.append((txt, complete,
-                                    self.eos, self.fname, self.lineno))
-            self.lineno += 1
-            return complete
-
-        for t in text.split('\n'):
-            self.input_complete = addTextInput(t)
-
-        if self.interactive:
-            self.prompt = self.ps2
-            while not self.input_complete:
-                t = self.input()
-                if len(t) > 0:
-                    self.input_complete = addTextInput(t)
-
-        if self.input_complete:
-            self.prompt = self.ps1
-            nkeys, nblock = self.convert()
-
-        return self.input_complete
+    def __len__(self):
+        return self.queue.qsize()
 
     def get(self):
         """get compile-able block of python code"""
-        if len(self) > 0:
-            if not self._fifo[0]:
-                self._fifo.reverse()
-                self._fifo[0].reverse()
-            try:
-                return  self._fifo[0].pop()
-            except IndexError:
-                msg = 'InputText out of complete text'
-                if self._larch is None:
-                    raise IndexError(msg)
-                else:
-                    self._larch.raise_exception(None, exc=IndexError, msg=msg)
-        return self.empty_frame
+        out = []
+        filename, linenumber = None, None
+        if self.saved_text != BLANK_TEXT:
+            txt, filename, lineno = self.saved_text
+            out.append(txt)
+        text, fn, ln, done = self.queue.get()
+        out.append(text)
+        if filename is None:
+            filename = fn
+        if linenumber is None:
+            linenumber = ln
 
-    def clean_text(self, text):
-        """  clean up text: strip comments,etc"""
-        text  = text.strip().rstrip()
-        # here we replace '#end' with '&end' so that it is not removed
-        # by strip_comments.  then below, we look for '&end' as an
-        # end-of-block token.
-        if text.startswith('#end'):
-            text = '&end%s' % text[4:]
-        return strip_comments(text)
-
-    def convert(self):
-        """
-        Convert input buff (in self.input_buff) to valid python code
-        and stores this (text, filename, lineno) into _fifo buffer
-        """
-        indent_level = 0
-        oneliner  = False
-        startkeys = self.block_friends.keys()
-        valid_cmds = []
-        if self._larch is not None:
-            valid_cmds = self._larch.symtable.get_symbol('_sys.valid_commands')
-
-        self.input_buff.reverse()
-        while self.input_buff:
-            text, complete, eos, fname, lineno = self.input_buff.pop()
-
-            text = self.clean_text(text)
-
-            long_text = eos in '"\''
-            sindent = self.indent*(indent_level+1)
-            while not complete:
-                tnext, complete, xeos, fname, lineno2 = self.input_buff.pop()
-                text = self.clean_text(text)
-                if long_text:
-                    text = "%s\n%s" % (text, tnext)
-                else:
-                    text = "%s\n  %s%s" % (text, sindent, tnext)
-
-
-
-            if text.startswith('"') or text.startswith("'"):
-                delim = text[0]
-                if text[0:3] == text[0]*3: # triple quote
-                    delim = text[0:3]
-                while not find_delims(text, delim=delim)[0]:
-                    tnext, complete, eos, fname, lineno2 = self.input_buff.pop()
-                    text = "%s\n %s%s" % (text, sindent, tnext)
-
-            txt   = text.replace('(', ' (')
-            words = txt.split(' ', 1)
-            thiskey = words.pop(0).strip()
-
-            word2 = ''
-            if len(words) > 0:
-                word2 = words[0].strip()
-
-            if thiskey.endswith(':'):
-                thiskey = thiskey[:-1]
-
-            prefix, oneliner = '', False
-
-            if thiskey in startkeys:
-                # note that we **re-test** here,
-                # as thiskey may have changed above for defined variables
-                if thiskey in startkeys:
-                    if text.find(':') < 1:
-                        msg = "%s statement needs a ':' at\n  %s" % (thiskey,
-                                                                     text)
-                        if self._larch is None:
-                            raise SyntaxError(msg)
-                        else:
-                            self._larch.raise_exception(None, exc=SyntaxError, msg=msg, expr=text)
-                    elif text.endswith(':'):
-                        self.current = thiskey
-                        self.keys.append(thiskey)
-                        self.friends = self.block_friends[thiskey]
-                        self.endkeys = ('end', 'end%s'% thiskey,
-                                        '&end', '&end%s'% thiskey)
-                    else: # one-liner form
-                        oneliner = True
-            elif thiskey in self.endkeys: # end of block
-                if not thiskey.startswith('#'):
-                    prefix = '#'
-                if len(self.keys) != 0:
-                    self.current = None
-                    self.friends = ()
-                    self.keys.pop()
-                    if len(self.keys)>0:
-                        self.current = self.keys[-1]
-                        self.friends = self.block_friends[self.current]
-                        self.endkeys = ('end',  'end%s'%self.current,
-                                        '&end', '&end%s'%self.current)
-
-            elif thiskey in valid_cmds and line_complete(word2):
-                if word2.startswith('(') and word2.endswith(')'):
-                    text = '%s%s' % (thiskey, word2)
-                else:
-                    text = '%s(%s)' % (thiskey, word2)
-            indent_level = len(self.keys)
-            if (not oneliner and len(thiskey)>0 and
-                (thiskey == self.current or thiskey in self.friends)):
-                indent_level = indent_level - 1
-
-            if indent_level < 0:
-                msg = 'impossible indent level!'
-                if self._larch is None:
-                    raise SyntaxError(msg)
-                else:
-                    self._larch.raise_exception(None, exc=SyntaxError, msg=msg)
-
-            pytext = '%s%s%s' % (self.indent*indent_level,
-                                 prefix, text)
-            self.block.append(pytext)
-            if len(self.keys) == 0:
-                outtext = '\n'.join(self.block)
-                if '\n' in outtext:  outtext = outtext  + '\n'
-                self._fifo[1].append((outtext, fname,
-                                      1+lineno-len(self.block)))
-                self.block = []
-
-        return len(self.keys), len(self.block)
+        while not done:
+            if self.queue.qsize() == 0:
+                self.saved_text = ("\n".join(out), filename, linenumber)
+                return BLANK_TEXT
+            text, fn, ln, done = self.queue.get()
+            out.append(text)
+        self.saved_text = BLANK_TEXT
+        return ("\n".join(out), filename, linenumber)
 
     def clear(self):
-        "clear the input"
-        self.prompt = self.ps1
-        self._fifo  = [[], []]
-        self.block  = []
-        self.keys   = []
-        self.current = None
-        self.endkeys = ()
-        self.friends = ()
-        self.delims = []
-        self.eos = ''
-        self.in_string   = False
-        self.input_buff  = []
-        self.input_complete = True
+        while not self.queue.empty():
+            self.queue.get()
+        self.saved_text = BLANK_TEXT
 
-    def __isComplete(self, txt, verbose=False):
-        """returns whether input text is a complete:
-        completeness here means the text (possibly multiline)
-        contains completed quotes, and parens, braces, brackets
-        are matched (including nesting) and the text does not
-        end with a backslash.
+    def put(self, text, filename=None, lineno=None):
+        """add line of input code text"""
+        if filename is not None:
+            self.filename = filename
+        if lineno is not None:
+            self.lineno = lineno
 
-        state information from previous text_complete() are stored in:
-           self.eos    = substring to look for 'end of string'
-                        (self.eos == "" means string is complete)
-           self.delims = current list of closing delims needed to match
-                         opening delims seen so far.
-        """
-        if len(txt) == 0:
-            return True
-        def find_eostring(txt, eos, istart):
-            while True:
-                inext = txt[istart:].find(eos)
-                if inext < 0:  # reached end of text before match found
-                    return eos, len(txt)
-                elif (txt[istart+inext-1] == BSLASH and
-                      txt[istart+inext-2] != BSLASH):  # matched quote was escaped
-                    istart = istart+inext+len(eos)
-                else: # real match found! skip ahead in string
-                    return '', istart+inext+len(eos)-1
+        if self._larch is not None:
+            getsym = self._larch.symtable.get_symbol
+            self.valid_cmds = getsym('_sys.valid_commands', create=True)
 
-        if self.eos != '':
-            self.eos, i = find_eostring(txt, self.eos, 0)
-            return self.eos == ''
+        for txt in text.split('\n'):
+            self.lineno += 1
+            if len(self.curtext) == 0:
+                self.curtext = txt
+                self.curline = self.lineno
+            else:
+                self.curtext = "%s\n%s" % (self.curtext, txt)
 
-        i = 0
-        delims = self.delims
-        while i < len(txt):
-            c = txt[i]
-            if c in QUOTES:
-                self.eos = c
-                if txt[i:i+3] == c*3:
-                    self.eos = c*3
-                istart = i + len(self.eos)
-                self.eos, i = find_eostring(txt, self.eos, istart)
-            elif c in OPENS:
-                delims.append(PARENS[c])
-            elif c in CLOSES and len(delims)>0 and c == delims[-1]:
-                delims.pop()
-            elif c == COMMENT and self.eos == '': # comment char outside string
-                i = len(txt)
-            i += 1
+            if is_complete(self.curtext) and len(self.curtext)>0:
+                blk_start =  block_start(self.curtext)
+                if blk_start:
+                    self.delims.append(blk_start)
+                else:
+                    blk_end = block_end(self.curtext)
+                    if (blk_end and len(self.delims) > 0 and
+                        blk_end == self.delims[-1]):
+                        self.delims.pop()
+                        if self.curtext.strip().startswith('end'):
+                            nblank = self.curtext.find(self.curtext.strip())
+                            self.curtext = '%s#%s' % (' '*nblank,
+                                                      self.curtext.strip())
 
-        complete = (self.eos == '' and len(delims) == 0 and
-                    not txt.rstrip().endswith(BSLASH))
-        if verbose:
-            print(' %s:%s:%i:%s ' % (complete, self.eos, len(delims), txt))
-        return complete
+                _delim = None
+                if len(self.delims) > 0:
+                    _delim = self.delims[-1]
 
+                key = get_key(self.curtext)
+                ilevel = len(self.delims)
+                if ilevel > 0 and (key == _delim or
+                                   key in BLOCK_FRIENDS[_delim]):
+                    ilevel = ilevel - 1
 
-    def __len__(self):
-        return len(self._fifo[0]) + len(self._fifo[1])
+                sindent = ' '*4*ilevel
+                pytext = "%s%s" % (sindent, self.curtext.strip())
+                # look for valid commands
+                if key in self.valid_cmds and '\n' not in self.curtext:
+                    argtext = self.curtext.strip()[len(key):].strip()
+                    if not (argtext.startswith('(') and
+                            argtext.endswith(')') ):
+                        pytext  = "%s%s(%s)" % (sindent, key, argtext)
 
-    def __defaultInput(self, prompt=None):
-        if prompt is None:
-            prompt = self.prompt
-        return input(prompt)
+                self.queue.put((pytext, self.filename, self.curline, 0==len(self.delims)))
+                self.curtext = ''
 
-if __name__ == '__main__':
-    inp = InputText()
-    inp.interactive = False
-    inp.put("x = 1;a = x/3.;b = sqrt(")
-    inp.put("a)")
-
-    while inp:
-        print( inp.get())
-    print( 'done')
-
-    buff = ['x = 1',
-            'y = x /2',
-            'for i in range(10):',
-            ' print i',
-            '    j = x *y * i',
-            '#endfor',
-            'print j ',
-            'def x1a = x + y ',
-            'if x < 1: ',
-            '  u = x/2',
-            '  if u < 1:  u = 2 ',
-            'else: ',
-            '  u = x/3',
-            '#endif ',
-            'set y = 22, z=29',
-                 '# comment!',
-                 '"quote"',
-                 '"escaped \\""',
-                 'x = "escaped \\" quote!"',
-                 '"""triple quote!"""',
-                 'x = """triple quote %s """ % ("x")',
-                 "x = {'H': 1, 'He':2}",
-                 '''""" this is a
-                 multiline
-                 triple-quote"""
-                 ''',
-
-                 '''""" this is a
-                 multiline with 'quotes'
-                 of both 'single' and "double" flavors!
-                 and # a single commented 'quote
-                 and a non-comment single quote:
-                 we're on in this together quote...
-                 nice, huh!
-                 """
-                 ''',
-                 """x = {'a': '''multiline
-                  dict value''',
-                  'b':10,
-                 'c':20} """,
-
-            ]
-    buff = ['''  """x = {'a': 'value',
-    'b':10,
-    'c':20} """
-    ''']
-
-
-    for t in buff:
-        inp.put(t)
-
-    import ast
-    while inp:
-        text, fname, lineno = inp.get()
-        text.rstrip()
-        print( '=====')
-        print( '%s' % text)
-        a = ast.parse(text)
-        print( ast.dump(a, include_attributes=False))
-
-    must_fail = [' " ',
-                 " we're all in this together ",
-                 ' ( # )',  ' {',
-                 'x = "e x\\"',
-                 'x = " a # and a () ',
-                 ]
-
-#
-#     testcode = """
-#  y = 4
-#  z = 1
-# # start my for loop
-# for i in range(100):
-# y = y * (1 + i) / 7.
-#    while y < 9:
-#
-#       y = y + 3
-# # comment in a nested block
-#       print 'XXX ', y
-#       endwhile
-#    if y > 4000: break
-#    if (y < 20 and
-#        y != 7):
-#       y = y-2
-#     endif
-# print i, y
-# endfor
-# print 'final y = ', y
-# """
-# #    for i in testcode.split('\n'):     inp.put(i.strip())
-#
+    @property
+    def complete(self):
+        return len(self.curtext)==0 and len(self.delims)==0

--- a/lib/inputText.py
+++ b/lib/inputText.py
@@ -171,13 +171,10 @@ class InputText:
                 self.clear()
                 writer.write('Traceback (most recent calls last): \n', **eopts)
                 for eblock, efname, elineno in larch_call_stack:
+                    text = "File %s, line %i" % (efname, elineno)
                     if efname != fname and elineno != lineno:
-                        etext = eblock.split('\n')[0]
-                        writer.write('   File %s, line %i\n    %s\n' %
-                                     (efname, elineno, etext), **eopts)
-                    else:
-                        writer.write('   File %s, line %i\n' %
-                                     (efname, elineno), **eopts)
+                        text =  "%s\n    %s" % (text, eblock.split('\n')[0])
+                    writer.write('   %s\n' % (text), **eopts)
 
                 errors_seen = []
                 for err in _larch.error:

--- a/lib/inputText.py
+++ b/lib/inputText.py
@@ -177,10 +177,11 @@ class InputText:
                         print("Python Call Stack ", frame)
 
                 if larch_call_stack > 1:
-                    for eblock, efname, elineno in larch_call_stack[1:]:
-                        etext = eblock.split('\n')[0]
-                        writer.write(' File %s, line %i\n  %s\n' % (efname, elineno, etext),
-                                     **eopts)
+                    for eblock, efname, elineno in larch_call_stack:
+                        if efname != fname and elineno != lineno:
+                            etext = eblock.split('\n')[0]
+                            writer.write(' File %s, line %i\n  %s\n' %
+                                         (efname, elineno, etext), **eopts)
                 for err in _larch.error:
                     writer.write("%s\n" % err.get_error()[1], **eopts)
 

--- a/lib/inputText.py
+++ b/lib/inputText.py
@@ -160,6 +160,10 @@ class InputText:
 
         def addTextInput(txt):
             complete = self.__isComplete(txt)
+            if complete:
+                self.eos = ""
+                self.delims = []
+
             self.input_buff.append((txt, complete,
                                     self.eos, self.fname, self.lineno))
             self.lineno += 1
@@ -347,7 +351,8 @@ class InputText:
            self.delims = current list of closing delims needed to match
                          opening delims seen so far.
         """
-
+        if len(txt) == 0:
+            return True
         def find_eostring(txt, eos, istart):
             while True:
                 inext = txt[istart:].find(eos)

--- a/lib/inputText.py
+++ b/lib/inputText.py
@@ -163,8 +163,10 @@ class InputText:
                     fname = err.fname
                     if err.lineno is not None:
                         lineno = err.lineno
-                if err.tback is not None:
+                if False and err.tback is not None:
+                    writer.write("<TRACE> ")
                     writer.write(err.tback, **eopts)
+                    writer.write("\n")
                 if False:
                     for err in _larch.error:
                         writer.write("%s\n" % (err.get_error()[1]), **eopts)
@@ -230,11 +232,11 @@ class InputText:
             if is_complete(self.curtext) and len(self.curtext)>0:
                 blk_start =  block_start(self.curtext)
                 if blk_start:
-                    self.blocks.append(blk_start)
+                    self.blocks.append((blk_start, self.lineno, text))
                 else:
                     blk_end = block_end(self.curtext)
                     if (blk_end and len(self.blocks) > 0 and
-                        blk_end == self.blocks[-1]):
+                        blk_end == self.blocks[-1][0]):
                         self.blocks.pop()
                         if self.curtext.strip().startswith('end'):
                             nblank = self.curtext.find(self.curtext.strip())
@@ -243,7 +245,7 @@ class InputText:
 
                 _delim = None
                 if len(self.blocks) > 0:
-                    _delim = self.blocks[-1]
+                    _delim = self.blocks[-1][0]
 
                 key = get_key(self.curtext)
                 ilevel = len(self.blocks)

--- a/lib/interpreter.py
+++ b/lib/interpreter.py
@@ -233,8 +233,8 @@ class Interpreter:
             self.fname  = fname
         if expr  is not None:
             self.expr   = expr
-        if func is not None:
-            self.func = func
+        # if func is not None:
+        self.func = func
 
         # get handler for this node:
         #   on_xxx with handle nodes of type 'xxx', etc

--- a/lib/interpreter.py
+++ b/lib/interpreter.py
@@ -184,9 +184,8 @@ class Interpreter:
 
         if len(self.error) > 0 and not isinstance(node, ast.Module):
             msg = '%s' % msg
-        err = LarchExceptionHolder(node, exc=exc, msg=msg, expr=expr,
-                                   fname=fname, lineno=lineno, func=func,
-                                   symtable=self.symtable)
+        err = LarchExceptionHolder(node=node, exc=exc, msg=msg, expr=expr,
+                                   fname=fname, lineno=lineno, func=func)
         self._interrupt = ast.Break()
         self.error.append(err)
         self.symtable._sys.last_error = err
@@ -400,11 +399,11 @@ class Interpreter:
         elif ctx == ast.Param:  # for Function Def
             val = str(node.id)
         else:
-            # val = self.symtable.get_symbol(node.id)
             try:
                 val = self.symtable.get_symbol(node.id)
             except (NameError, LookupError):
                 msg = "name '%s' is not defined" % node.id
+                val = None
                 self.raise_exception(node, msg=msg)
         return val
 

--- a/lib/larchlib.py
+++ b/lib/larchlib.py
@@ -106,7 +106,7 @@ class LarchExceptionHolder:
         if fname != '<stdin>' or self.lineno > 0:
             if fname != '<stdin>':
                 self.lineno = self.lineno + 1
-        fline = 'file %s, line %i' % (fname, self.lineno)
+        fline = ' File %s, line %i' % (fname, self.lineno)
         if self.func is not None:
             func = self.func
             fname = self.fname
@@ -125,7 +125,7 @@ class LarchExceptionHolder:
             for tb in traceback.extract_tb(self.exc_info[2]):
                 found = found or tb[0].startswith(fname)
                 if found:
-                    u = 'File "%s", line %i, in %s\n    %s' % tb
+                    u = ' File "%s", line %i, in %s\n    %s' % tb
                     words = u.split('\n')
                     fline = words[0]
                     call_expr = self.expr
@@ -189,9 +189,9 @@ class LarchExceptionHolder:
                 out.append("    %s^^^" % ((col_offset)*' '))
 
         if call_expr is not None and not isinstance(call_expr, ast.AST):
-            out.append('  %s' % call_expr)
             if call_fname is not None and call_lineno is not None:
-                out.append('file %s, line %i' % (call_fname, call_lineno))
+                out.append(' File %s, line %i' % (call_fname, call_lineno))
+            out.append(call_expr)
 
         return (exc_name, '\n'.join(out))
 

--- a/lib/larchlib.py
+++ b/lib/larchlib.py
@@ -103,9 +103,6 @@ class LarchExceptionHolder:
         call_lineno = None
         fname = self.fname
 
-        if fname != '<stdin>' or self.lineno > 0:
-            if fname != '<stdin>':
-                self.lineno = self.lineno + 1
         fline = ' File %s, line %i' % (fname, self.lineno)
         if self.func is not None:
             func = self.func

--- a/lib/larchlib.py
+++ b/lib/larchlib.py
@@ -46,7 +46,7 @@ ReturnedNone = Empty()
 
 def get_filetext(fname, lineno):
     """try to extract line from source text file"""
-    out = ''
+    out = '<could not find text>'
     try:
         ftmp = open(fname, 'r')
         lines = ftmp.readlines()
@@ -105,7 +105,7 @@ class LarchExceptionHolder:
         if col_offset > 0:
             out.append("%s^^^" % ((col_offset)*' '))
 
-        fline = '  File %s, line %i' % (fname, self.lineno)
+        fline = '   File %s, line %i' % (fname, self.lineno)
         if self.func is not None:
             func = self.func
             fname = self.fname

--- a/lib/larchlib.py
+++ b/lib/larchlib.py
@@ -182,7 +182,7 @@ class LarchExceptionHolder:
                 out.append(' File %s, line %i' % (call_fname, call_lineno))
             out.append(call_expr)
 
-        return '\n'.join(out)
+        return (exc_name, '\n'.join(out))
 
     def get_error_old_DONT_USE(self, fname=None, lineno=None):
 

--- a/lib/shell.py
+++ b/lib/shell.py
@@ -45,7 +45,6 @@ class shell(cmd.Cmd):
         self.larch  = Interpreter()
         self.input  = InputText(_larch=self.larch)
         self.prompt = self.ps1
-        self.buffer = []
 
         writer = self.larch.writer
         if not quiet:
@@ -96,7 +95,7 @@ class shell(cmd.Cmd):
         self.input.put(text)
         complete = self.input.complete
         if complete:
-            complete, self.buffer = self.input.run(buffer=self.buffer)
+            complete = self.input.run()
         self.prompt = {True:self.ps1, False:self.ps2}[complete]
 
 if __name__ == '__main__':

--- a/lib/shell.py
+++ b/lib/shell.py
@@ -4,7 +4,7 @@ import cmd
 import os
 import sys
 import numpy
-import larch
+
 from .interpreter import Interpreter
 from .site_config import history_file, show_site_config
 from .version import __version__, __date__, make_banner
@@ -103,40 +103,6 @@ class shell(cmd.Cmd):
 
         self.input.put(text)
         self.prompt, self.buffer = self.input.run(buffer=self.buffer)
-
-        old = """
-        while len(self.input) > 0:
-            block, fname, lineno = self.input.get()
-            self.buffer.append(block)
-            if not self.input.complete:
-                continue
-
-            ret = self.larch.eval('\n'.join(self.buffer),
-                                  fname=fname, lineno=lineno)
-            self.prompt = self.ps1
-            self.buffer = []
-            if self.larch.error:
-                self.input.clear()
-                eopts = self.termcolor_opts('error', _larch=self.larch)
-                err = self.larch.error.pop(0)
-                if err.fname is not None:
-                    fname = err.fname
-                    if err.lineno is not None:
-                        lineno = err.lineno
-                if err.tback is not None:
-                    write(err.tback, **eopts)
-                if self.debug:
-                    for err in self.larch.error:
-                        write("%s\n" % (err.get_error()[1]), **eopts)
-                thiserr = err.get_error(fname=fname, lineno=lineno)
-                write("%s\n" % thiserr[1], **eopts)
-                break
-            elif ret is not None:
-                wopts = self.termcolor_opts('text', _larch=self.larch)
-                write("%s\n" % repr(ret), **wopts)
-
-        self.larch.writer.flush()
-        """
 
 if __name__ == '__main__':
     t = shell(debug=True).cmdloop()

--- a/lib/shell.py
+++ b/lib/shell.py
@@ -71,6 +71,9 @@ class shell(cmd.Cmd):
     def emptyline(self):
         pass
 
+    def onecmd(self, text):
+        return self.default(text)
+
     def do_help(self, txt):
         if txt.startswith('(') and txt.endswith(')'):
             txt = txt[1:-1]
@@ -92,7 +95,7 @@ class shell(cmd.Cmd):
             self.write_history(trim_last=trim_last)
             return True
 
-        self.input.put(text)
+        self.input.put(text, filename='<stdin>', lineno=0)
         complete = self.input.complete
         if complete:
             complete = self.input.run()

--- a/lib/shell.py
+++ b/lib/shell.py
@@ -54,7 +54,6 @@ class shell(cmd.Cmd):
             writer.write("\n")
 
         self.larch.run_init_scripts()
-        self.termcolor_opts = self.larch.symtable._builtin.get_termcolor_opts
 
     def __del__(self, *args):
         self._write_history()
@@ -87,10 +86,7 @@ class shell(cmd.Cmd):
         self.default(text)
 
     def default(self, text):
-        txt = text.strip()
-        write = self.larch.writer.write
-
-        if txt in ('quit', 'exit', 'EOF'):
+        if text.strip() in ('quit', 'exit', 'EOF'):
             if HAS_READLINE:
                 try:
                     n = readline.get_current_history_length()
@@ -102,7 +98,10 @@ class shell(cmd.Cmd):
             return True
 
         self.input.put(text)
-        self.prompt, self.buffer = self.input.run(buffer=self.buffer)
+        complete = self.input.complete
+        if complete:
+            complete, self.buffer = self.input.run(buffer=self.buffer)
+        self.prompt = {True:self.ps1, False:self.ps2}[complete]
 
 if __name__ == '__main__':
     t = shell(debug=True).cmdloop()

--- a/lib/shell.py
+++ b/lib/shell.py
@@ -44,7 +44,7 @@ class shell(cmd.Cmd):
         if banner_msg is None:
             banner_msg = make_banner()
         self.larch  = Interpreter()
-        self.input  = InputText( _larch=self.larch)
+        self.input  = InputText(_larch=self.larch)
         self.prompt = self.ps1
         self.buffer = []
 
@@ -101,10 +101,10 @@ class shell(cmd.Cmd):
                 self.history_written = True
             return True
 
-        ret = None
-        self.prompt = self.ps2
         self.input.put(text)
+        self.prompt, self.buffer = self.input.run(buffer=self.buffer)
 
+        old = """
         while len(self.input) > 0:
             block, fname, lineno = self.input.get()
             self.buffer.append(block)
@@ -136,6 +136,7 @@ class shell(cmd.Cmd):
                 write("%s\n" % repr(ret), **wopts)
 
         self.larch.writer.flush()
+        """
 
 if __name__ == '__main__':
     t = shell(debug=True).cmdloop()

--- a/lib/shell.py
+++ b/lib/shell.py
@@ -107,12 +107,7 @@ class shell(cmd.Cmd):
             self.history_written = True
             return 1
 
-        if text.startswith('help'):
-            arg = text[4:]
-            if arg.startswith('(') and arg.endswith(')'): arg = arg[1:-1]
-            if arg.startswith("'") and arg.endswith("'"): arg = arg[1:-1]
-            if arg.startswith('"') and arg.endswith('"'): arg = arg[1:-1]
-            text  = "help(%s)"% (repr(arg))
+        #    text  = "help(%s)"% (repr(arg))
         if text.startswith('!'):
             os.system(text[1:])
         else:

--- a/lib/symboltable.py
+++ b/lib/symboltable.py
@@ -12,14 +12,10 @@ from .utils import Closure, fixName, isValidName
 from . import site_config
 
 class Group(object):
-    """Generic Group: a container for variables, modules, and subgroups.
-
-    Methods
-    ----------
-       _subgroups(): return list of subgroups
-       _members():   return dict of members
     """
-    __private = ('_main', '_larch', '_parents', '__name__',
+    Generic Group: a container for variables, modules, and subgroups.
+    """
+    __private = ('_main', '_larch', '_parents', '__name__', '__doc__', 
                  '__private', '_subgroups', '_members')
     def __init__(self, name=None, **kws):
         if name is None:

--- a/lib/symboltable.py
+++ b/lib/symboltable.py
@@ -480,6 +480,8 @@ class SymbolTable(Group):
         if registrar is None:
             return
         groupname, syms = registrar()
+        if not isinstance(syms, dict):
+            raise ValueError('add_plugin requires dictionary of plugins')
 
         if not self.has_group(groupname):
             self.new_group(groupname)

--- a/lib/utils/jsonutils.py
+++ b/lib/utils/jsonutils.py
@@ -2,7 +2,7 @@
 """
  json utilities for larch objects
 """
-
+import six
 import larch
 from larch import isParameter, Parameter, isgroup, Group
 
@@ -25,7 +25,7 @@ def encode4js(obj):
         return out
     elif isinstance(obj, (np.float, np.int)):
         return float(obj)
-    elif isinstance(obj, (np.str, np.unicode)):
+    elif isinstance(obj, six.string_types):
         return str(obj)
     elif isinstance(obj, np.complex):
         return {'__class__': 'Complex', 'value': (obj.real, obj.imag)}

--- a/lib/utils/strutils.py
+++ b/lib/utils/strutils.py
@@ -13,7 +13,7 @@ if sys.version_info[0] == 3:
             return s
         elif isinstance(s, bytes):
             return s.decode(sys.stdout.encoding)
-        return str(s)
+        return str(s, sys.stdout.encoding)
 
 
 def PrintExceptErr(err_str, print_trace=True):

--- a/lib/wxlib/__init__.py
+++ b/lib/wxlib/__init__.py
@@ -5,4 +5,4 @@ wx widgets for Larch
 from . import larchframe
 from . import larchfilling
 from . import readlinetextctrl
-
+from .columnframe import EditColumnFrame

--- a/lib/wxlib/columnframe.py
+++ b/lib/wxlib/columnframe.py
@@ -1,0 +1,337 @@
+#!/usr/bin/env python
+"""
+
+"""
+import os
+import numpy as np
+np.seterr(all='ignore')
+
+import wx
+import wx.lib.scrolledpanel as scrolled
+
+from wxmplot import PlotFrame
+from wxutils import (SimpleText, FloatCtrl, pack, Button,
+                     Choice,  Check, MenuItem, GUIColors,
+                     CEN, RCEN, LCEN, FRAMESTYLE, Font)
+
+from larch_plugins.io import fix_varname
+
+CEN |=  wx.ALL
+
+
+XPRE_OPS = ('', 'log(', '-log(')
+YPRE_OPS = ('', 'log(', '-log(')
+ARR_OPS = ('+', '-', '*', '/')
+
+def okcancel(panel, onOK=None, onCancel=None):
+    btnsizer = wx.StdDialogButtonSizer()
+    _ok = wx.Button(panel, wx.ID_OK)
+    _no = wx.Button(panel, wx.ID_CANCEL)
+    panel.Bind(wx.EVT_BUTTON, onOK,     _ok)
+    panel.Bind(wx.EVT_BUTTON, onCancel, _no)
+    _ok.SetDefault()
+    btnsizer.AddButton(_ok)
+    btnsizer.AddButton(_no)
+    btnsizer.Realize()
+    return btnsizer
+
+
+class EditColumnFrame(wx.Frame) :
+    """Set Column Labels for a file"""
+    def __init__(self, parent, group=None, last_array_sel=None,
+                 read_ok_cb=None, edit_groupname=True):
+        self.parent = parent
+        self.dgroup = group
+        if not hasattr(self.dgroup, 'is_xas'):
+            try:
+                self.dgroup.is_xas = 'energ' in self.dgroup.array_labels[0].lower()
+            except:
+                self.dgroup.is_xas = False
+        self.read_ok_cb = read_ok_cb
+
+        self.array_sel = {'xpop': '', 'xarr': None,
+                          'ypop': '', 'yop': '/',
+                          'yarr1': None, 'yarr2': None,
+                          'use_deriv': False}
+        if last_array_sel is not None:
+            self.array_sel.update(last_array_sel)
+
+        if self.array_sel['yarr2'] is None and 'i0' in self.dgroup.array_labels:
+            self.array_sel['yarr2'] = 'i0'
+
+        if self.array_sel['yarr1'] is None:
+            if 'itrans' in self.dgroup.array_labels:
+                self.array_sel['yarr1'] = 'itrans'
+            elif 'i1' in self.dgroup.array_labels:
+                self.array_sel['yarr1'] = 'i1'
+        message = "Build Arrys from Data Columns for %s" % self.dgroup.filename
+        wx.Frame.__init__(self, None, -1, 'Build Arrays from Data Columns for %s' % self.dgroup.filename,
+                          style=FRAMESTYLE)
+
+        self.SetFont(Font(10))
+        panel = scrolled.ScrolledPanel(self)
+        self.SetMinSize((600, 600))
+        self.colors = GUIColors()
+        self.plotframe = None
+
+        # title row
+        title = SimpleText(panel, message, font=Font(13),
+                           colour=self.colors.title, style=LCEN)
+
+        opts = dict(action=self.onColumnChoice, size=(120, -1))
+
+        arr_labels = self.dgroup.array_labels
+        yarr_labels = arr_labels + ['1.0', '0.0', '']
+        xarr_labels = arr_labels + ['<index>']
+
+        self.xarr   = Choice(panel, choices=xarr_labels, **opts)
+        self.yarr1  = Choice(panel, choices= arr_labels, **opts)
+        self.yarr2  = Choice(panel, choices=yarr_labels, **opts)
+
+        opts['size'] = (90, -1)
+
+        self.xpop = Choice(panel, choices=XPRE_OPS, **opts)
+        self.ypop = Choice(panel, choices=YPRE_OPS, **opts)
+        opts['size'] = (50, -1)
+        self.yop =  Choice(panel, choices=ARR_OPS, **opts)
+
+        ylab = SimpleText(panel, 'Y = ')
+        xlab = SimpleText(panel, 'X = ')
+        self.xsuf = SimpleText(panel, '')
+        self.ysuf = SimpleText(panel, '')
+
+        self.xpop.SetStringSelection(self.array_sel['xpop'])
+        self.ypop.SetStringSelection(self.array_sel['ypop'])
+        self.yop.SetStringSelection(self.array_sel['yop'])
+        if '(' in self.array_sel['ypop']:
+            self.ysuf.SetLabel(')')
+
+        ixsel, iysel, iy2sel = 0, 1, len(yarr_labels)-1
+        if self.array_sel['xarr'] in xarr_labels:
+            ixsel = xarr_labels.index(self.array_sel['xarr'])
+        if self.array_sel['yarr1'] in arr_labels:
+            iysel = arr_labels.index(self.array_sel['yarr1'])
+        if self.array_sel['yarr2'] in yarr_labels:
+            iy2sel = yarr_labels.index(self.array_sel['yarr2'])
+        self.xarr.SetSelection(ixsel)
+        self.yarr1.SetSelection(iysel)
+        self.yarr2.SetSelection(iy2sel)
+
+        opts['size'] = (150, -1)
+        self.use_deriv = Check(panel, label='use derivative',
+                               default=self.array_sel['use_deriv'], **opts)
+
+        self.is_xas = Check(panel, label='use as XAS data',
+                               default=self.dgroup.is_xas, **opts)
+
+        bpanel = wx.Panel(panel)
+        bsizer = wx.BoxSizer(wx.HORIZONTAL)
+        bsizer.Add(Button(bpanel, 'Preview', action=self.onColumnChoice), 4)
+        bsizer.Add(Button(bpanel, 'OK', action=self.onOK), 4)
+        bsizer.Add(Button(bpanel, 'Cancel', action=self.onCancel), 4)
+        pack(bpanel, bsizer)
+
+        sizer = wx.GridBagSizer(4, 8)
+        sizer.Add(title,     (0, 0), (1, 7), LCEN, 5)
+
+        ir = 1
+        sizer.Add(xlab,      (ir, 0), (1, 1), CEN, 0)
+        sizer.Add(self.xpop, (ir, 1), (1, 1), CEN, 0)
+        sizer.Add(self.xarr, (ir, 2), (1, 1), CEN, 0)
+        sizer.Add(self.xsuf, (ir, 3), (1, 1), CEN, 0)
+
+        ir += 1
+        sizer.Add(ylab,       (ir, 0), (1, 1), CEN, 0)
+        sizer.Add(self.ypop,  (ir, 1), (1, 1), CEN, 0)
+        sizer.Add(self.yarr1, (ir, 2), (1, 1), CEN, 0)
+        sizer.Add(self.yop,   (ir, 3), (1, 1), CEN, 0)
+        sizer.Add(self.yarr2, (ir, 4), (1, 1), CEN, 0)
+        sizer.Add(self.ysuf,  (ir, 5), (1, 1), CEN, 0)
+
+        ir += 1
+        sizer.Add(self.use_deriv, (ir, 0), (1, 3), LCEN, 0)
+        ir += 1
+        sizer.Add(self.is_xas, (ir, 0), (1, 3), LCEN, 0)
+
+        self.wid_groupname = None
+        if edit_groupname:
+            wid_grouplab = SimpleText(panel, 'Use Group Name: ')
+            self.wid_groupname = wx.TextCtrl(panel, value=self.dgroup._groupname,
+                                             size=(100, -1))
+            ir += 1
+            sizer.Add(wid_grouplab,     (ir, 0), (1, 2), LCEN, 3)
+            sizer.Add(self.wid_groupname, (ir, 2), (1, 3), LCEN, 3)
+
+        ir += 1
+        sizer.Add(bpanel,     (ir, 0), (1, 5), LCEN, 3)
+
+        pack(panel, sizer)
+
+
+        ftext = wx.TextCtrl(self, style=wx.TE_MULTILINE|wx.TE_READONLY,
+                               size=(-1, 150))
+        try:
+            m = open(self.dgroup.filename, 'r')
+            text = m.read()
+            m.close()
+        except:
+            text = "The file '%s'\n was not found" % self.dgroup.filename
+        ftext.SetValue(text)
+        ftext.SetFont(Font(9))
+
+        mainsizer = wx.BoxSizer(wx.VERTICAL)
+        mainsizer.Add(panel, 0, wx.GROW|wx.ALL, 2)
+        mainsizer.Add(ftext, 1, LCEN|wx.GROW,   2)
+        pack(self, mainsizer)
+
+        self.Show()
+        self.Raise()
+
+    def onOK(self, event=None):
+        """ build arrays according to selection """
+
+        if not hasattr(self.dgroup, '_xdat'):
+            self.onColumnChoice()
+
+        if self.wid_groupname is not None:
+            self.dgroup._groupname = fix_varname(self.wid_groupname.GetValue())
+        if self.plotframe is not None:
+            try:
+                self.plotframe.Destroy()
+            except:
+                pass
+        if self.read_ok_cb is not None:
+            self.read_ok_cb(self.dgroup, self.array_sel)
+        self.Destroy()
+
+    def onCancel(self, event=None):
+        self.dgroup.import_ok = False
+        if self.plotframe is not None:
+            self.plotframe.Destroy()
+        self.Destroy()
+
+    def onColumnChoice(self, evt=None):
+        """column selections changed calc _xdat and _ydat"""
+        # dtcorr = self.dtcorr.IsChecked()
+        dtcorr = False
+        use_deriv = self.use_deriv.IsChecked()
+        dgroup = self.dgroup
+
+        ix  = self.xarr.GetSelection()
+        xname = self.xarr.GetStringSelection()
+        if xname == '<index>':
+            xname = self.dgroup.array_labels[0]
+            dgroup._index = 1.0*np.arange(len(getattr(dgroup, xname)))
+            xname = '_index'
+
+        dgroup.is_xas = self.is_xas.IsChecked()
+        dgroup._xdat = getattr(dgroup, xname)
+
+        def do_preop(opwid, arr):
+            opstr = opwid.GetStringSelection().strip()
+            suf = ''
+            if opstr in ('-log(', 'log('):
+                suf = ')'
+                if opstr == 'log(':
+                    arr = np.log(arr)
+                elif opstr == '-log(':
+                    arr = -np.log(arr)
+            return suf, opstr, arr
+
+        xsuf, xpop, dgroup._xdat = do_preop(self.xpop, dgroup._xdat)
+        self.xsuf.SetLabel(xsuf)
+
+        try:
+            xunits = dgroup.array_units[ix].strip()
+            xlabel = '%s (%s)' % (xname, xunits)
+        except:
+            xlabel = xname
+
+
+        def get_data(group, arrayname, correct=False):
+            if hasattr(group, 'get_data'):
+                return group.get_data(arrayname, correct=correct)
+            return getattr(group, arrayname, None)
+
+        yname1  = self.yarr1.GetStringSelection().strip()
+        yname2  = self.yarr2.GetStringSelection().strip()
+        yop = self.yop.GetStringSelection().strip()
+
+        ylabel = yname1
+        if len(yname2) == 0:
+            yname2, yop = '1.0', '*'
+        else:
+            ylabel = "%s%s%s" % (ylabel, yop, yname2)
+
+        yarr1 = get_data(dgroup, yname1, correct=dtcorr)
+
+        if yname2 in ('0.0', '1.0'):
+            yarr2 = float(yname2)
+            if yop == '/': yarr2 = 1.0
+        else:
+            yarr2 = get_data(dgroup, yname2, correct=dtcorr)
+
+        dgroup._ydat = yarr1
+        if yop == '+':
+            dgroup._ydat = yarr1.__add__(yarr2)
+        elif yop == '-':
+            dgroup._ydat = yarr1.__sub__(yarr2)
+        elif yop == '*':
+            dgroup._ydat = yarr1.__mul__(yarr2)
+        elif yop == '/':
+            dgroup._ydat = yarr1.__truediv__(yarr2)
+
+
+        ysuf, ypop, dgroup._ydat = do_preop(self.ypop, dgroup._ydat)
+        self.ysuf.SetLabel(ysuf)
+
+        if use_deriv:
+            try:
+                dgroup._ydat = np.gradient(dgroup._ydat)/np.gradient(dgroup._xdat)
+            except:
+                pass
+
+        self.array_sel = {'xpop': xpop, 'xarr': xname,
+                     'ypop': ypop, 'yop': yop,
+                     'yarr1': yname1, 'yarr2': yname2,
+                     'use_deriv': use_deriv}
+
+
+        try:
+            npts = min(len(dgroup._xdat), len(dgroup._ydat))
+        except AttributeError:
+            print( 'Error calculating arrays (npts not correct)')
+            return
+
+        dgroup._npts       = npts
+        dgroup.plot_xlabel = xlabel
+        dgroup.plot_ylabel = ylabel
+        dgroup._xdat       = np.array( dgroup._xdat[:npts])
+        dgroup._ydat       = np.array( dgroup._ydat[:npts])
+        if dgroup.is_xas:
+            dgroup.energy = dgroup._xdat
+            dgroup.mu     = dgroup._ydat
+
+        self.raise_plotframe()
+
+        ppanel = self.plotframe.panel
+
+        popts = {}
+        path, fname = os.path.split(dgroup.filename)
+
+        popts['label'] = "%s: %s" % (fname, dgroup.plot_ylabel)
+        popts['title']  = fname
+        popts['ylabel'] = dgroup.plot_ylabel
+        popts['xlabel'] = dgroup.plot_xlabel
+
+        ppanel.plot(dgroup._xdat, dgroup._ydat, **popts)
+
+    def raise_plotframe(self):
+        if self.plotframe is not None:
+            try:
+                self.plotframe.Show()
+            except:
+                self.plotframe = None
+        if self.plotframe is None:
+            self.plotframe = PlotFrame(None, size=(650, 400))
+            self.plotframe.Show()

--- a/lib/wxlib/larchfilling.py
+++ b/lib/wxlib/larchfilling.py
@@ -41,7 +41,7 @@ VERSION = '0.9.5(Larch)'
 
 COMMONTYPES = [int, float, complex, bool, str, dict, list, tuple, numpy.ndarray]
 if sys.version[0] == '2':
-    COMMONTYPES.append(unicode)
+   COMMONTYPES.append(unicode)
 COMMONTYPES =  tuple(COMMONTYPES)
 
 H5TYPES = ()

--- a/lib/wxlib/larchfilling.py
+++ b/lib/wxlib/larchfilling.py
@@ -13,13 +13,6 @@ __revision__ = "$Revision: 37633 $"
 
 
 import sys
-if not hasattr(sys, 'frozen'):
-    try:
-        import wxversion
-        wxversion.ensureMinimal('2.8')
-    except:
-        pass
-
 import wx
 import numpy
 import wx.html as html

--- a/lib/wxlib/larchframe.py
+++ b/lib/wxlib/larchframe.py
@@ -43,6 +43,7 @@ class LarchWxShell(object):
         self.prompt = prompt
         self.output = output
         if self.output is not None:
+            self.encoding = sys.stdout.encoding
             sys.stdout = self
 
         self.input  = input

--- a/lib/wxlib/larchframe.py
+++ b/lib/wxlib/larchframe.py
@@ -37,7 +37,11 @@ class LarchWxShell(object):
         self.symtable = self.larch.symtable
         self.prompt = prompt
         self.output = output
+        if self.output is not None:
+            sys.stdout = self
+
         self.input  = input
+        self.objtree = wxparent.objtree
         self.larch.writer = self
         self.larch.add_plugin('wx', wxparent=wxparent)
         self.symtable.set_symbol('_builtin.force_wxupdate', False)
@@ -97,12 +101,15 @@ class LarchWxShell(object):
             sfont = style.GetFont()
             pos1  = self.output.GetLastPosition()
             self.output.SetStyle(pos0, pos1, wx.TextAttr(color, bgcol, sfont))
-        # self.flush()
 
     def flush(self, *args):
-        self.output.SetInsertionPoint(self.output.GetLastPosition())
+        try:
+            self.output.SetInsertionPoint(self.output.GetLastPosition())
+        except:
+            pass
         self.output.Refresh()
         self.output.Update()
+        wx.CallAfter(self.objtree.onRefresh)
         self.needs_flush = False
 
     def clear_input(self):
@@ -360,7 +367,6 @@ class LarchFrame(wx.Frame):
         else:
             self.input.AddToHistory(text)
             wx.CallAfter(self.larchshell.execute, text)
-            wx.CallAfter(self.objtree.onRefresh)
 
     def onChangeDir(self, event=None):
         dlg = wx.DirDialog(None, 'Choose a Working Directory',

--- a/lib/wxlib/larchframe.py
+++ b/lib/wxlib/larchframe.py
@@ -133,10 +133,9 @@ class LarchWxShell(object):
             else:
                 self.inptext.put(text)
 
-        buffer = []
         complete = self.inptext.complete
         if complete:
-            complete, buffer = self.inptext.run(buffer=buffer, writer=self)
+            complete = self.inptext.run(writer=self)
         self.SetPrompt(complete)
 
 class LarchFrame(wx.Frame):

--- a/lib/wxlib/larchframe.py
+++ b/lib/wxlib/larchframe.py
@@ -37,7 +37,7 @@ class LarchWxShell(object):
         self.larch = _larch
         if _larch is None:
             self.larch  = larch.Interpreter()
-        self.inptext  = larch.InputText(prompt=self.ps1, _larch=self.larch)
+        self.inptext  = larch.InputText(_larch=self.larch)
 
         self.symtable = self.larch.symtable
         self.prompt = prompt
@@ -132,7 +132,7 @@ class LarchWxShell(object):
             else:
                 self.inptext.put(text,lineno=0)
 
-        if not self.inptext.input_complete:
+        if not self.inptext.complete:
             self.SetPrompt(partial = True)
             return None
 

--- a/lib/wxlib/readlinetextctrl.py
+++ b/lib/wxlib/readlinetextctrl.py
@@ -3,13 +3,6 @@
 from __future__ import print_function
 import sys
 
-if not hasattr(sys, 'frozen'):
-    try:
-        import wxversion
-        wxversion.ensureMinimal('2.8')
-    except:
-        pass
-
 import wx
 import os
 import time

--- a/lib/xmlrpc_server.py
+++ b/lib/xmlrpc_server.py
@@ -11,12 +11,6 @@ from larch.interpreter import Interpreter
 from larch.inputText import InputText
 from larch.utils.jsonutils import encode4js
 
-if not hasattr(sys, 'frozen'):
-    try:
-        import wxversion
-        wxversion.ensureMinimal('2.8')
-    except:
-        pass
 try:
     import wx
     from larch.wxlib import inputhook

--- a/plugins/epics/larchscan.py
+++ b/plugins/epics/larchscan.py
@@ -89,6 +89,7 @@ from threading import Thread
 import json
 import numpy as np
 import random
+import six
 
 from datetime import timedelta
 
@@ -364,7 +365,7 @@ class LarchStepScan(object):
 
     def add_counter(self, counter, label=None):
         "add simple counter"
-        if isinstance(counter, (str, unicode)):
+        if isinstance(counter, six.string_types):
             counter = Counter(counter, label)
         if counter not in self.counters:
             self.counters.append(counter)
@@ -374,7 +375,7 @@ class LarchStepScan(object):
         "add simple detector trigger"
         if trigger is None:
             return
-        if isinstance(trigger, (str, unicode)):
+        if isinstance(trigger, six.string_types):
             trigger = Trigger(trigger, label=label, value=value)
         if trigger not in self.triggers:
             self.triggers.append(trigger)

--- a/plugins/io/athena_project.py
+++ b/plugins/io/athena_project.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python
+"""
+Code to read (and write) Athena Project files
+
+"""
+import sys
+import os
+import json
+from fnmatch import fnmatch
+from  gzip import GzipFile
+from glob import glob
+
+import numpy as np
+from larch import Group
+from larch_plugins.io import fix_varname
+
+if sys.version[0] == '2':
+    from string import maketrans
+else:
+    maketrans = str.maketrans
+
+alist2json = str.maketrans("();'\n", "[] \" ")
+def perl2json(text):
+    return json.loads(text.split('=')[1].strip().translate(alist2json))
+
+
+ERR_MSG = "Error reading Athena Project File"
+def read_athena(filename, match=None, do_preedge=True,
+                do_bkg=True, do_fft=True, _larch=None):
+    """read athena project file
+    returns a Group of Groups, one for each Athena Group in the project file
+
+    Arguments:
+        filename (string): name of Athena Project file
+        match (sring): pattern to use to limit imported groups (see Note 1)
+        do_preedge (bool): whether to do pre-edge subtraction [True]
+        do_bkg (bool): whether to do XAFS background subtraction [True]
+        do_fft (bool): whether to do XAFS Fast Fourier transform [True]
+
+    Returns:
+        group of groups each named according the label used by Athena.
+
+    Notes:
+        1. To limit the imported groups, use the pattern in `match`,
+        using '*' to match 'all' '?' to match any single character,
+        or [sequence] to match any of a sequence of letters.  The matching
+        will always be insensitive to case.
+        2. do_preedge,  do_bkg, and do_fft will attempt to reproduce the
+        pre-edge, background subtraction, and FFT from Athena by using
+        the parameters saved in the project file.
+
+    Example:
+        1. read in all groups from a project file:
+           cr_data = read_athena('My Cr Project.prj')
+
+        2. read in only the "merged" data from a Project, and don't do FFT:
+           zn_data = read_athena('Zn on Stuff.prj', match='*merge*', do_fft=False)
+
+    """
+
+    from larch_plugins.xafs import pre_edge, autobk, xftf
+    if not os.path.exists(filename):
+        raise IOError("%s '%s': cannot find file" % (ERR_MSG, filename))
+
+    try:
+        fh = GzipFile(filename)
+        lines = [str(t, sys.stdin.encoding) for t in fh.readlines()]
+        fh.close()
+    except:
+        raise ValueError("%s '%s': invalid gzip file" % (ERR_MSG, fname))
+
+    athenagroups = []
+    dat = {'name':''}
+    Athena_version  = None
+    vline = lines.pop(0)
+    if  "Athena project file -- Demeter version" not in vline:
+        raise ValueError("%s '%s': invalid Athena File" % (ERR_MSG, fname))
+
+    major, minor, fix = '0', '0', '0'
+    try:
+        vs = vline.split("Athena project file -- Demeter version")[1]
+        major, minor, fix = vs.split('.')
+    except:
+        raise ValueError("%s '%s': cannot read version" % (ERR_MSG, fname))
+    if int(minor) < 9 or int(fix[:2]) < 21:
+        raise ValueError("%s '%s': file is too old to read" % (ERR_MSG, fname))
+
+    for t in lines:
+        if t.startswith('#') or len(t) < 2:
+            continue
+        key = t.split(' ')[0].strip()
+        key = key.replace('$', '').replace('@', '')
+        if key == 'old_group':
+            dat['name'] = perl2json(t)
+        elif key == '[record]':
+            athenagroups.append(dat)
+            dat = {'name':''}
+        elif key == 'args':
+            dat['args'] = perl2json(t)
+        elif key in ('x', 'y', 'i0'):
+            dat[key] = np.array([float(x) for x in perl2json(t)])
+
+    if match is not None:
+        match = match.lower()
+
+    out = Group()
+    for dat in athenagroups:
+        label = dat['name']
+        this = Group(athena_id=label, energy=dat['x'], mu=dat['y'],
+                     bkg_params=Group(), fft_params = Group(),
+                     athena_params=Group())
+        if 'i0' in dat:
+            this.i0 = dat['i0']
+        if 'args' in dat:
+            for i in range(len(dat['args'])//2):
+                key = dat['args'][2*i]
+                val = dat['args'][2*i+1]
+                if key.startswith('bkg_'):
+                    setattr(this.bkg_params, key[4:], val)
+                elif key.startswith('fft_'):
+                    setattr(this.fft_params, key[4:], val)
+                elif key == 'label':
+                    label = this.label = val
+                else:
+                    setattr(this.athena_params, key, val)
+        olabel = fix_varname(label)
+        if match is not None:
+            if not fnmatch(olabel.lower(), match):
+                continue
+
+        if do_preedge or do_bkg:
+            pars = this.bkg_params
+            pre_edge(this, _larch=_larch, e0=float(pars.e0),
+                     pre1=float(pars.pre1), pre2=float(pars.pre2),
+                     norm1=float(pars.nor1), norm2=float(pars.nor2),
+                     nnorm=float(pars.nnorm)-1,
+                     make_flat=bool(pars.flatten))
+
+            if do_bkg and hasattr(pars, 'rbkg'):
+                autobk(this, _larch=_larch, e0=float(pars.e0),
+                       rbkg=float(pars.rbkg), kmin=float(pars.spl1),
+                       kmax=float(pars.spl2), kweight=float(pars.kw),
+                       dk=float(pars.dk), clamp_lo=float(pars.clamp1),
+                       clamp_hi=float(pars.clamp2))
+
+        if do_fft:
+            pars = this.fft_params
+            kweight=2
+            if hasattr(pars, 'kw'):
+                kweight = float(pars.kw)
+            xftf(this, _larch=_larch, kmin=float(pars.kmin),
+                 kmax=float(pars.kmax), kweight=kweight,
+                 window=pars.kwindow, dk=float(pars.dk))
+
+        setattr(out, olabel, this)
+    return out
+
+def registerLarchPlugin():
+    return ('_io', {'read_athena': read_athena})

--- a/plugins/io/athena_project.py
+++ b/plugins/io/athena_project.py
@@ -12,6 +12,7 @@ from glob import glob
 
 import numpy as np
 from larch import Group
+from larch.utils.strutils import bytes2str
 from larch_plugins.io import fix_varname
 
 if sys.version[0] == '2':
@@ -19,7 +20,7 @@ if sys.version[0] == '2':
 else:
     maketrans = str.maketrans
 
-alist2json = str.maketrans("();'\n", "[] \" ")
+alist2json = maketrans("();'\n", "[] \" ")
 def perl2json(text):
     return json.loads(text.split('=')[1].strip().translate(alist2json))
 
@@ -64,26 +65,26 @@ def read_athena(filename, match=None, do_preedge=True,
 
     try:
         fh = GzipFile(filename)
-        lines = [str(t, sys.stdin.encoding) for t in fh.readlines()]
+        lines = [bytes2str(t) for t in fh.readlines()]
         fh.close()
     except:
-        raise ValueError("%s '%s': invalid gzip file" % (ERR_MSG, fname))
+        raise ValueError("%s '%s': invalid gzip file" % (ERR_MSG, filename))
 
     athenagroups = []
     dat = {'name':''}
     Athena_version  = None
     vline = lines.pop(0)
     if  "Athena project file -- Demeter version" not in vline:
-        raise ValueError("%s '%s': invalid Athena File" % (ERR_MSG, fname))
+        raise ValueError("%s '%s': invalid Athena File" % (ERR_MSG, filename))
 
     major, minor, fix = '0', '0', '0'
     try:
         vs = vline.split("Athena project file -- Demeter version")[1]
         major, minor, fix = vs.split('.')
     except:
-        raise ValueError("%s '%s': cannot read version" % (ERR_MSG, fname))
+        raise ValueError("%s '%s': cannot read version" % (ERR_MSG, filename))
     if int(minor) < 9 or int(fix[:2]) < 21:
-        raise ValueError("%s '%s': file is too old to read" % (ERR_MSG, fname))
+        raise ValueError("%s '%s': file is too old to read" % (ERR_MSG, filename))
 
     for t in lines:
         if t.startswith('#') or len(t) < 2:

--- a/plugins/io/fileutils.py
+++ b/plugins/io/fileutils.py
@@ -2,6 +2,10 @@
 """
 general purpose file utilities
 """
+MODDOC = '''
+Functions for Input/Output, especially reading specific types
+of scientific data files.
+'''
 
 import time
 import os
@@ -9,49 +13,35 @@ import sys
 from random import seed, randrange
 from string import printable
 
-BAD_FILECHARS = ';~,`!%$@?*#:"/|\'\\\t\r\n (){}[]<>'
+if sys.version[0] == '3':
+    maketrans = str.maketrans
+else:
+    from string import maketrans
+
+BAD_FILECHARS = ';~,`!%$@$&^?*#:"/|\'\\\t\r\n (){}[]<>'
 GOOD_FILECHARS = '_'*len(BAD_FILECHARS)
 
-MODDOC = '''
-Functions for Input/Output, especially reading specific types
-of scientific data files.
-'''
+BAD_VARSCHARS = BAD_FILECHARS + '+-.'
+GOOD_VARSCHARS = '_'*len(BAD_VARSCHARS)
 
-if sys.version[0] == '2':
-    from string import maketrans
-    BAD_FILETABLE = maketrans(BAD_FILECHARS, GOOD_FILECHARS)
-    def fix_filename(s):
-        """fix string to be a 'good' filename.
-        This may be a more restrictive than the OS, but
-        avoids nasty cases."""
-        t = str(s).translate(BAD_FILETABLE)
-        if t.count('.') > 1:
-            for i in range(t.count('.') - 1):
-                idot = t.find('.')
-                t = "%s_%s" % (t[:idot], t[idot+1:])
-        return t
-    def fix_varname(s):
-        """fix string to be a 'good' variable name."""
-        t = str(s).translate(BAD_FILETABLE)
-        while t.endswith('_'): t = t[:-1]
-        return t
+TRANS_FILE = maketrans(BAD_FILECHARS, GOOD_FILECHARS)
+TRANS_VARS = maketrans(BAD_VARSCHARS, GOOD_VARSCHARS)
 
-elif sys.version[0] == '3':
-    def fix_filename(s):
-        """fix string to be a 'good' filename.
-        This may be a more restrictive than the OS, but
-        avoids nasty cases."""
-        t = s.translate(s.maketrans(BAD_FILECHARS, GOOD_FILECHARS))
-        if t.count('.') > 1:
-            for i in range(t.count('.') - 1):
-                idot = t.find('.')
-                t = "%s_%s" % (t[:idot], t[idot+1:])
-        return t
-    def fix_varname(s):
-        """fix string to be a 'good' variable name."""
-        t = s.translate(s.maketrans(BAD_FILECHARS, GOOD_FILECHARS))
-        while t.endswith('_'): t = t[:-1]
-        return t
+def fix_filename(s):
+    """fix string to be a 'good' filename.
+    This may be a more restrictive than the OS, but
+    avoids nasty cases."""
+    t = str(s).translate(TRANS_FILE)
+    if t.count('.') > 1:
+        for i in range(t.count('.') - 1):
+            idot = t.find('.')
+            t = "%s_%s" % (t[:idot], t[idot+1:])
+    return t
+def fix_varname(s):
+    """fix string to be a 'good' variable name."""
+    t = str(s).translate(TRANS_VARS)
+    while t.endswith('_'): t = t[:-1]
+    return t
 
 def strip_quotes(t):
     d3, s3, d1, s1 = '"""', "'''", '"', "'"
@@ -308,7 +298,6 @@ def test_incrementfilename():
         else:
             npass = npass + 1
     print('Passed %i of %i tests' % (npass, npass+nfail))
-
 
 
 

--- a/plugins/io/xdi.py
+++ b/plugins/io/xdi.py
@@ -252,12 +252,17 @@ def read_xdi(fname, _larch=None):
     """simple mapping of XDI file to larch groups"""
     x = XDIFile(fname)
     group = _larch.symtable.create_group()
-    group.__name__ ='XDI file %s' % fname
     for key, val in x.__dict__.items():
         if not key.startswith('_'):
             if six.PY3 and key in string_attrs:
                 val = tostr(val)
             setattr(group, key, val)
+    group.__name__ ='XDI file %s' % fname
+    doc = ['%i arrays, %i npts' % (x.narrays, x.npts)]
+    arr_labels = getattr(x, 'array_labels', None)
+    if arr_labels is not None:
+        doc.append("Array Labels: %s" % repr(arr_labels))
+    group.__doc__ = '\n'.join(doc)
     return group
 
 def registerLarchPlugin():

--- a/plugins/std/shellutils.py
+++ b/plugins/std/shellutils.py
@@ -11,6 +11,7 @@ import os
 import sys
 from copy import copy, deepcopy
 from glob import glob
+import six
 from larch import ValidateLarchPlugin
 
 MODNAME = '_builtin'
@@ -65,7 +66,7 @@ def _mkdir(name, mode=0o777, **kws):
     """create directory (and any intermediate subdirectories
 
     Options:
-    --------   
+    --------
       mode   permission mask to use for creating directory (default=0777)
     """
     return os.makedirs(name, mode=mode)
@@ -75,7 +76,7 @@ def show_more(text, filename=None, writer=None,
               pagelength=30, prefix='', _larch=None, **kws):
     """show lines of text in the style of more """
     txt = text[:]
-    if isinstance(txt, (str, unicode)):
+    if isinstance(txt, six.string_types):
         txt = txt.split('\n')
     if len(txt) <1:
         return
@@ -137,6 +138,6 @@ def initializeLarchPlugin(_larch=None):
 
 def registerLarchPlugin():
     return ('_builtin', {'copy': _copy, 'deepcopy': _deepcopy,
-                         'more': _more, 'parent': _parent,  
+                         'more': _more, 'parent': _parent,
                          'ls': _ls,  'mkdir': _mkdir,
                          'cd': _cd,  'cwd': _cwd })

--- a/plugins/std/show.py
+++ b/plugins/std/show.py
@@ -6,6 +6,7 @@ import os
 import sys
 import types
 import numpy
+import six
 from larch import Group, ValidateLarchPlugin
 
 TERMCOLOR_COLORS = ('grey', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white')
@@ -27,7 +28,7 @@ def get(sym=None, _larch=None, **kws):
         group = sym
     elif isinstance(sym, types.ModuleType):
         group = sym
-    elif isinstance(sym, (str, unicode)):
+    elif isinstance(sym, six.string_types):
         group = symtable._lookup(sym, create=False)
     return group
 

--- a/plugins/wx/mapimageframe.py
+++ b/plugins/wx/mapimageframe.py
@@ -266,7 +266,7 @@ class MapImageFrame(ImageFrame):
         if event.xdata is None or event.ydata is None:
             return
 
-        ix, iy = round(event.xdata), round(event.ydata)
+        ix, iy = int(round(event.xdata)), int(round(event.ydata))
         conf = self.panel.conf
         if conf.flip_ud:  iy = conf.data.shape[0] - iy
         if conf.flip_lr:  ix = conf.data.shape[1] - ix

--- a/plugins/wx/mapviewer.py
+++ b/plugins/wx/mapviewer.py
@@ -252,7 +252,7 @@ class MapMathPanel(scrolled.ScrolledPanel):
     def onShowMap(self, event=None, new=True):
         mode = self.map_mode.GetStringSelection()
         def get_expr(wid):
-            val = str(wid.Value)
+            val = bytes2str(wid.Value)
             if len(val) == 0:
                 val = '1'
             return val
@@ -277,7 +277,7 @@ class MapMathPanel(scrolled.ScrolledPanel):
             else:
                 map = self.owner.filemap[fname].get_roimap(roiname, det=det, dtcorrect=dtcorr)
 
-            _larch.symtable.set_symbol(str(varname), map)
+            _larch.symtable.set_symbol(bytes2str(varname), map)
             if main_file is None:
                 main_file = self.owner.filemap[fname]
         if mode.startswith('I'):
@@ -693,11 +693,11 @@ class MapInfoPanel(scrolled.ScrolledPanel):
         for i, comm in enumerate(comments):
             self.wids['User Comments %i' %(i+1)].SetLabel(comm)
 
-        pos_addrs = [str(x) for x in xrfmap['config/positioners'].keys()]
-        pos_label = [str(x.value) for x in xrfmap['config/positioners'].values()]
+        pos_addrs = [bytes2str(x) for x in xrfmap['config/positioners'].keys()]
+        pos_label = [bytes2str(x.value) for x in xrfmap['config/positioners'].values()]
 
-        scan_pos1 = str(xrfmap['config/scan/pos1'].value)
-        scan_pos2 = str(xrfmap['config/scan/pos2'].value)
+        scan_pos1 = bytes2str(xrfmap['config/scan/pos1'].value)
+        scan_pos2 = bytes2str(xrfmap['config/scan/pos2'].value)
         i1 = pos_addrs.index(scan_pos1)
         i2 = pos_addrs.index(scan_pos2)
 
@@ -735,7 +735,7 @@ class MapInfoPanel(scrolled.ScrolledPanel):
         cur_energy = ''
 
         for name, addr, val in zip(env_names, env_addrs, env_vals):
-            name = str(name).lower()
+            name = bytes2str(name).lower()
             if 'ring current' in name:
                 self.wids['Ring Current'].SetLabel("%s mA" % val)
             elif 'mono energy' in name and cur_energy=='':
@@ -746,7 +746,7 @@ class MapInfoPanel(scrolled.ScrolledPanel):
             elif 'i0 current' in name:
                 i0vals['current'] = val
             else:
-                addr = str(addr)
+                addr = bytes2str(addr)
                 if addr.endswith('.VAL'):
                     addr = addr[:-4]
                 if addr in pos_addrs:
@@ -1078,7 +1078,7 @@ WARNING: This cannot be undone!
     def onLabel(self, event=None):
         aname = self._getarea()
         area  = self.owner.current_file.xrfmap['areas/%s' % aname]
-        new_label = str(self.desc.GetValue())
+        new_label = bytes2str(self.desc.GetValue())
         area.attrs['description'] = new_label
         self.owner.current_file.h5root.flush()
         self.set_area_choices(self.owner.current_file.xrfmap)
@@ -1310,11 +1310,11 @@ class MapViewerFrame(wx.Frame):
             return
 
         xrfmap = self.current_file.xrfmap
-        pos_addrs = [str(x) for x in xrfmap['config/positioners'].keys()]
-        pos_label = [str(x.value) for x in xrfmap['config/positioners'].values()]
+        pos_addrs = [bytes2str(x) for x in xrfmap['config/positioners'].keys()]
+        pos_label = [bytes2str(x.value) for x in xrfmap['config/positioners'].values()]
 
-        pos1 = str(xrfmap['config/scan/pos1'].value)
-        pos2 = str(xrfmap['config/scan/pos2'].value)
+        pos1 = bytes2str(xrfmap['config/scan/pos1'].value)
+        pos2 = bytes2str(xrfmap['config/scan/pos2'].value)
         i1 = pos_addrs.index(pos1)
         i2 = pos_addrs.index(pos2)
         msg = "%s(%s) = %.4f, %s(%s) = %.4f?" % (pos_label[i1], pos_addrs[i1], xval,
@@ -1349,7 +1349,7 @@ class MapViewerFrame(wx.Frame):
             conf = xrfmap['config']
             pos_addrs = [pvn(tval) for tval in conf['positioners']]
             env_addrs = [pvn(tval) for tval in conf['environ/address']]
-            env_vals  = [str(tval) for tval in conf['environ/value']]
+            env_vals  = [bytes2str(tval) for tval in conf['environ/value']]
 
             position = {}
             for p in pos_addrs:
@@ -1530,7 +1530,7 @@ class MapViewerFrame(wx.Frame):
 
 
         if dlg.ShowModal() == wx.ID_OK:
-            basedir = os.path.abspath(str(dlg.GetPath()))
+            basedir = os.path.abspath(bytes2str(dlg.GetPath()))
             try:
                 if len(basedir)  > 0:
                     os.chdir(nativepath(basedir))
@@ -1599,12 +1599,12 @@ class MapViewerFrame(wx.Frame):
         dlg.Destroy()
         if read:
             #try:
-            xrmfile = GSEXRM_MapFile(folder=str(path))
+            xrmfile = GSEXRM_MapFile(folder=bytes2str(path))
             #except:
             #    Popup(self, NOT_GSEXRM_FOLDER % str(path),
             #         "Not a Map folder")
             #    return
-            parent, fx = os.path.split(str(path))
+            parent, fx = os.path.split(bytes2str(path))
             self.add_xrmfile(xrmfile)
 
     def add_xrmfile(self, xrmfile):
@@ -1649,7 +1649,7 @@ class MapViewerFrame(wx.Frame):
 
         if read:
             parent, fname = os.path.split(path)
-            xrmfile = GSEXRM_MapFile(filename=str(path))
+            xrmfile = GSEXRM_MapFile(filename=bytes2str(path))
             self.add_xrmfile(xrmfile)
 
     def onWatchFiles(self, event=None):

--- a/plugins/xafs/feffdat.py
+++ b/plugins/xafs/feffdat.py
@@ -12,7 +12,7 @@ the path represented by the feffNNNN.dat
 
 creates a group that contains the chi(k) for the sum of paths.
 """
-
+import six
 import numpy as np
 from scipy.interpolate import UnivariateSpline
 from larch import (Group, Parameter, isParameter,
@@ -240,7 +240,7 @@ class FeffPathGroup(Group):
             if param in kws:
                 if kws[param] is not None:
                     val = kws[param]
-            if isinstance(val, (str, unicode)):
+            if isinstance(val, six.string_types):
                 thispar = Parameter(expr=val, _larch=self._larch)
 
                 #if isinstance(thispar, Parameter):

--- a/plugins/xafs/feffit.py
+++ b/plugins/xafs/feffit.py
@@ -189,7 +189,7 @@ class FeffitDataSet(Group):
         self.__chi = interp(self.model.k, self.data.k, self.data.chi)
         self.n_idp = 1 + 2*(trans.rmax-trans.rmin)*(trans.kmax-trans.kmin)/pi
         # print(" Prepare fit " , hasattr(self.data, 'epsilon_k'))
-        if hasattr(self.data, 'epsilon_k'):
+        if getattr(self.data, 'epsilon_k', None) is not None:
             eps_k = self.data.epsilon_k
             if isinstance(eps_k, np.ndarray):
                 eps_k = interp(self.model.k, self.data.k, self.data.epsilon_k)
@@ -285,8 +285,6 @@ class FeffitDataSet(Group):
         eps_k = self.epsilon_k
         if isinstance(eps_k, np.ndarray):
             eps_k[np.where(eps_k<1.e-12)[0]] = 1.e-12
-        else:
-            eps_k = max(1.e-12, eps_k)
 
         diff  = (self.__chi - self.model.chi)
         if data_only:  # for extracting transformed data separately from residual

--- a/plugins/xafs/pre_edge.py
+++ b/plugins/xafs/pre_edge.py
@@ -158,10 +158,8 @@ def preedge(energy, mu, e0=None, step=None,
     p2 = index_nearest(energy, norm2+e0)
     if p2-p1 < 2:
         p2 = min(len(energy), p1 + 2)
-    if nnorm == 0:
-        coefs = [omu[p1:p2].mean()]
-    else:
-        coefs = polyfit(energy[p1:p2], omu[p1:p2], nnorm)
+
+    coefs = polyfit(energy[p1:p2], omu[p1:p2], nnorm-1)
     post_edge = 0
     norm_coefs = []
     for n, c in enumerate(reversed(list(coefs))):
@@ -238,7 +236,6 @@ def pre_edge(energy, mu=None, group=None, e0=None, step=None,
        If it exists, group.e0 will be used as e0.
        See First Argrument Group in Documentation
     """
-
 
 
     energy, mu, group = parse_group_args(energy, members=('energy', 'mu'),

--- a/plugins/xray/xraydb.py
+++ b/plugins/xray/xraydb.py
@@ -9,6 +9,7 @@ Main Class for full Database:  xrayDB
 import os
 import time
 import json
+import six
 import numpy as np
 from scipy.interpolate import interp1d, splrep, splev, UnivariateSpline
 from sqlalchemy import MetaData, create_engine
@@ -53,7 +54,7 @@ def isxrayDB(dbname):
 
 def json_encode(val):
     "simple wrapper around json.dumps"
-    if val is None or isinstance(val, (str, unicode)):
+    if val is None or isinstance(val, six.string_types):
         return val
     return  json.dumps(val)
 

--- a/plugins/xrf/mca.py
+++ b/plugins/xrf/mca.py
@@ -7,6 +7,7 @@ Authors/Modifications:
 * Modified for Tdl, tpt
 * modified and simplified for Larch, M Newville
 """
+import six
 import numpy as np
 from larch import Group, isgroup
 
@@ -154,7 +155,7 @@ class MCA(Group):
             thisroi = roi
         elif isinstance(roi, int) and roi < len(self.rois):
             thisroi = self.rois[roi]
-        elif isinstance(roi, (str, unicode)):
+        elif isinstance(roi, six.string_types):
             rnames = [r.name.lower() for r in self.rois]
             for iroi, nam in enumerate(rnames):
                 if nam.startswith(roi.lower()):

--- a/plugins/xrf/xrf_peak.py
+++ b/plugins/xrf/xrf_peak.py
@@ -6,7 +6,7 @@ This is a Larch group representing a Peak in an XRF Spectrum.
   group  = xrf_peak()
 
 """
-
+import six
 import numpy as np
 from scipy.interpolate import UnivariateSpline
 from larch import (Group, Parameter, isParameter,
@@ -89,7 +89,7 @@ class XRFPeak(Group):
             if parname in kws:
                 if kws[parname] is not None:
                     val = kws[parname]
-            if isinstance(val, (str, unicode)):
+            if isinstance(val, six.string_types):
                 thispar = Parameter(expr=val, _larch=self._larch)
                 setattr(self, parname, thispar)
                 val = getattr(self, parname)

--- a/plugins/xrfmap/configfile.py
+++ b/plugins/xrfmap/configfile.py
@@ -3,7 +3,7 @@
 import os
 import sys
 import time
-
+import six
 if sys.version[0] == '2':
     from ConfigParser import  ConfigParser
     from cStringIO import StringIO
@@ -147,7 +147,8 @@ class FastMapConfig(object):
                 for opt in optlist:
                     try:
                         val = cnf[sect].get(opt,'<unknown>')
-                        if not isinstance(val,(str,unicode)): val = str(val)
+                        if not isinstance(val, six.string_types):
+                            val = str(val)
                         o.append("%s = %s" % (opt,val))
                     except:
                         pass
@@ -171,7 +172,8 @@ class FastMapConfig(object):
         for opt in optlist:
             val = scan.get(opt,None)
             if val is not None:
-                if not isinstance(val,(str,unicode)): val = str(val)
+                if not isinstance(val, six.string_types):
+                    val = str(val)
                 o.append("%s = %s" % (opt,val))
         o.append('#------------------#\n')
         f = open(fname,'w')

--- a/plugins/xrfmap/xrm_mapfile.py
+++ b/plugins/xrfmap/xrm_mapfile.py
@@ -555,8 +555,8 @@ class GSEXRM_MapFile(object):
     def get_coarse_stages(self):
         """return coarse stage positions for map"""
         stages = []
-        env_addrs = list(self.xrfmap['config/environ/address'])
-        env_vals  = list(self.xrfmap['config/environ/value'])
+        env_addrs = h5stringlist(self.xrfmap['config/environ/address'])
+        env_vals  = h5stringlist(self.xrfmap['config/environ/value'])
         for addr, pname in self.xrfmap['config/positioners'].items():
             name = str(pname.value)
             addr = str(addr)
@@ -905,8 +905,8 @@ class GSEXRM_MapFile(object):
         slope  = conf['mca_calib/slope'].value
         quad   = conf['mca_calib/quad'].value
 
-        roi_names = list(conf['rois/name'])
-        roi_addrs = list(conf['rois/address'])
+        roi_names = h5stringlist(conf['rois/name'])
+        roi_addrs = h5stringlist(conf['rois/address'])
         roi_limits = conf['rois/limits'].value
         for imca in range(nmca):
             dname = 'det%i' % (imca+1)
@@ -1549,9 +1549,9 @@ class GSEXRM_MapFile(object):
                    slope=cal['cal_slope'], **kws)
 
         _mca.energy =  map['energy'].value
-        env_names = list(self.xrfmap['config/environ/name'])
-        env_addrs = list(self.xrfmap['config/environ/address'])
-        env_vals  = list(self.xrfmap['config/environ/value'])
+        env_names = h5stringlist(self.xrfmap['config/environ/name'])
+        env_addrs = h5stringlist(self.xrfmap['config/environ/address'])
+        env_vals  = h5stringlist(self.xrfmap['config/environ/value'])
         for desc, val, addr in zip(env_names, env_vals, env_addrs):
             _mca.add_environ(desc=desc, val=val, addr=addr)
 
@@ -1563,7 +1563,7 @@ class GSEXRM_MapFile(object):
         roiname = 'roi_name'
         if roiname not in map:
             roiname = 'roi_names'
-        roinames = list(map[roiname])
+        roinames = h5stringlist(map[roiname])
         roilims  = list(map['roi_limits'])
         for roi, lims in zip(roinames, roilims):
             _mca.add_roi(roi, left=lims[0], right=lims[1])

--- a/setup.py
+++ b/setup.py
@@ -159,6 +159,22 @@ for pdir in pluginpaths:
     data_files.append((os.path.join(larchdir, pdir), pfiles))
 
 
+if (cmdline_args[0] == 'install' and
+    sys.platform == 'darwin' and
+    'Anaconda' in sys.version):
+    for fname in scripts:
+        fh = open(fname, 'r')
+        lines = fh.readlines()
+        fh.close()
+        line0 = lines[0].strip()
+        if not line0.startswith('#!/usr/bin/env pythonw'):
+            fh = open(fname, 'w')
+            fh.write('#!/usr/bin/env pythonw\n')
+            fh.write("".join(lines[1:]))
+            fh.close()
+            print("Rewrote ", fname)
+
+
 # now we have all the data files, so we can run setup
 setup(name = 'larch',
       version = version.__version__,
@@ -173,20 +189,6 @@ setup(name = 'larch',
       packages = ['larch', 'larch.utils', 'larch.wxlib',
                   'larch.fitting', 'larch.fitting.uncertainties'],
       data_files  = data_files)
-
-if cmdline_args[0] == 'install' and sys.platform == 'darwin':
-    dest = os.path.join(larchdir, 'apps')
-    try:
-        os.mkdir(apps)
-    except:
-        pass
-    for app in mac_apps:
-        _, aname = os.path.split(app)
-        adest = os.path.join(dest, aname)
-        if os.path.exists(adest):
-            shutil.rmtree(adest)
-
-        shutil.copytree(app, adest)
 
 
 def remove_cruft(basedir, filelist):

--- a/tests/test_larchexamples_basic.py
+++ b/tests/test_larchexamples_basic.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+""" Tests of Larch Scripts  """
+import unittest
+import time
+import ast
+import numpy as np
+from sys import version_info
+
+from utils import TestCase
+from larch import Interpreter
+class TestScripts(TestCase):
+    '''tests'''
+
+    def test_basic_interp(self):
+        self.runscript('interp.lar', dirname='../examples/basic/')
+        assert(len(self.session.get_errors()) == 0)
+        self.isNear("y0[1]", 0.535, places=2)
+        self.isNear("y1[1]", 0.829, places=2)
+        self.isNear("y2[1]", 0.477, places=2)
+
+    def test_basic_smooth(self):
+        self.runscript('smoothing.lar', dirname='../examples/basic/')
+        assert(len(self.session.get_errors()) == 0)
+        self.isNear("s_loren[5]", 0.207, places=2)
+        self.isNear("s_gauss[5]", 0.027, places=2)
+        self.isNear("s_voigt[5]", 0.256, places=2)
+
+    def test_basic_smooth(self):
+        self.runscript('local_namespaces.lar', dirname='../examples/basic/')
+        assert(len(self.session.get_errors()) == 0)
+        self.isNear("x", 1000.0, places=4)
+
+    def test_basic_pi(self):
+        self.runscript('pi_archimedes.lar', dirname='../examples/basic/')
+        assert(len(self.session.get_errors()) == 0)
+        self.isNear("result", 3.14159265358979267, places=8)
+
+    def test_basic_use_params(self):
+        self.runscript('use_params.lar', dirname='../examples/basic/')
+        assert(len(self.session.get_errors()) == 0)
+        self.isNear("a",  0.76863, places=4)
+
+
+if __name__ == '__main__':  # pragma: no cover
+    for suite in (TestScripts,):
+        suite = unittest.TestLoader().loadTestsFromTestCase(suite)
+        unittest.TextTestRunner(verbosity=13).run(suite)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -42,11 +42,13 @@ class LarchSession(object):
     def run(self, text):
         self.input.put(text)
         ret = None
+        buff = []
         while len(self.input) > 0:
             block, fname, lineno = self.input.get()
-            if len(block) <= 0:
+            buff.append(block)
+            if not self.input.complete:
                 continue
-            ret = self._larch.eval(block, fname=fname, lineno=lineno)
+            ret = self._larch.eval("\n".join(buff), fname=fname, lineno=lineno)
             if self._larch.error:
                 break
         return ret


### PR DESCRIPTION
This is sort of a sprawling collection of changes to make larch work better with wxPhoenix and with Python3.    The branch started as a need for a few fixes for Phoenix, and then morphed into more Python3 compatibility changes. 

Most recently, it inspired a long-needed and *complete* rewrite of "read input text, convert to Python code ready for evaluation" in `inputtext.py`, and so also the way this code is used in the command-line and GUI shell.    This was some of the oldest and also some of the worst code in larch.

The REPL code is now much simpler now and the use of REPL in the command-line `larch` program and `larch_gui` are now much more uniform, and work with both Python 2 and 3.

The basic and XAFS functionality in the plugins are also well-tested with Python3.   

Some of the other plugins and GUIs (especially, the reading of the GSECARS hdf5 maps and mapviewer) still have some Python3 problems.
