### PR TITLE
predictable column labels in read_ascii

### DIFF
--- a/doc/data/index.rst
+++ b/doc/data/index.rst
@@ -54,6 +54,7 @@ This file and others like it can be read with the builtin
    :type  commentchar:  string
    :param labels:  string to split for column labels
    :type labels:  string, ``None``, or ``False``
+   :type ilabels: boolean, column labels 'col1', 'col2', etc if True
 
     The commentchar argument (#;% by default) sets the valid comment characters:
     if the first character in a line matches one of these, the line is marked
@@ -74,6 +75,9 @@ This file and others like it can be read with the builtin
 
     If labels is ``False``, the group will have a *data* variable contain
     the 2-dimensional data.
+
+    If ilabels is ``True``, the column labels will be 'col1', 'col2', etc, regardless
+    of the column labels in the data file.
 
 Some examples of :func:`read_ascii`::
 

--- a/plugins/io/columnfile.py
+++ b/plugins/io/columnfile.py
@@ -30,10 +30,10 @@ def iso8601_time(ts):
     s = time.strftime("%Y-%m-%dT%H:%M:%S", time.localtime(ts))
     return "%s%s" % (s, tzone)
 
-def read_ascii(fname, labels=None, sort=False, sort_column=0, _larch=None):
+def read_ascii(fname, labels=None, sort=False, ilabels=False, sort_column=0, _larch=None):
     """read a column ascii column file, returning a group containing the data from the file.
 
-    read_ascii(filename, labels=None, sort=False, sort_column=0)
+    read_ascii(filename, labels=None, sort=False, ilabels=False, sort_column=0)
 
     If the header is one of the forms of
         KEY : VAL
@@ -43,7 +43,8 @@ def read_ascii(fname, labels=None, sort=False, sort_column=0, _larch=None):
     If labels is left the default value of None, column labels will be tried to
     be created from the line immediately preceeding the data, or using 'col1', 'col2',
     etc if column labels cannot be figured out.   The labels will be used to create
-    1-d arrays for each column
+    1-d arrays for each column.  If ilabels is True, the names 'col1', 'col2' etc will
+    be used regardless of the column labels found in the file.
 
     The group will have a 'data' component containing the 2-dimensional data, it will also
     have a 'header' component containing the text of the header -- an array of lines.
@@ -87,6 +88,8 @@ def read_ascii(fname, labels=None, sort=False, sort_column=0, _larch=None):
                 ncol = len(rowdat)
             if ncol == len(rowdat):
                 data.append(rowdat)
+    if ilabels:
+        _labelline = None
 
     # reverse header, footer, data, convert to arrays
     footers.reverse()


### PR DESCRIPTION
This PR adds an argument to read_ascii that forces the column labels
to be "col1", "col2", etc regardless of the column labels in the data
file.  This means that column labels can be completely predictable.

This PR includes a change to the relevant documentation page.