### PR TITLE
Saverestore with json

### DIFF
--- a/lib/interpreter.py
+++ b/lib/interpreter.py
@@ -275,6 +275,7 @@ class Interpreter:
         self.fname = fname
         self.lineno = lineno
         self.error = []
+        self.this_expr = expr
         try:
             node = self.parse(expr, fname=fname, lineno=lineno)
         except RuntimeError:

--- a/lib/symboltable.py
+++ b/lib/symboltable.py
@@ -149,7 +149,7 @@ class SymbolTable(Group):
         self._sys.moduleGroup = self
         self._sys.paramGroup = None
         self._sys.__cache__  = [None]*5
-
+        self._sys.saverestore_classes = []
         for g in self.core_groups:
             self._sys.searchGroups.append(g)
         self._sys.core_groups = tuple(self._sys.searchGroups[:])
@@ -471,6 +471,12 @@ class SymbolTable(Group):
         """
         if not isinstance(plugin, types.ModuleType):
             on_error("%s is not a valid larch plugin" % repr(plugin))
+
+        group_registrar = getattr(plugin, 'registerLarchGroups', None)
+        if callable(group_registrar):
+            savegroups = group_registrar()
+            for group in savegroups:
+                self._sys.saverestore_classes.append(group)
 
         registrar = getattr(plugin, 'registerLarchPlugin', None)
         if registrar is None:

--- a/lib/symboltable.py
+++ b/lib/symboltable.py
@@ -149,7 +149,7 @@ class SymbolTable(Group):
         self._sys.moduleGroup = self
         self._sys.paramGroup = None
         self._sys.__cache__  = [None]*5
-        self._sys.saverestore_classes = []
+        self._sys.saverestore_groups = []
         for g in self.core_groups:
             self._sys.searchGroups.append(g)
         self._sys.core_groups = tuple(self._sys.searchGroups[:])
@@ -476,7 +476,7 @@ class SymbolTable(Group):
         if callable(group_registrar):
             savegroups = group_registrar()
             for group in savegroups:
-                self._sys.saverestore_classes.append(group)
+                self._sys.saverestore_groups.append(group)
 
         registrar = getattr(plugin, 'registerLarchPlugin', None)
         if registrar is None:

--- a/lib/utils/jsonutils.py
+++ b/lib/utils/jsonutils.py
@@ -53,7 +53,10 @@ def encode4js(obj):
         for key, val in obj.items():
             out[encode4js(key)] = encode4js(val)
         return out
-    return obj
+    elif callable(obj):
+        return {'__class__': 'Method', '__name__': repr(obj)}
+
+    return repr(obj)
 
 def decode4js(obj):
     """

--- a/lib/utils/jsonutils.py
+++ b/lib/utils/jsonutils.py
@@ -27,8 +27,12 @@ def encode4js(obj, grouplist=None):
         out = {'__class__': 'Array', '__shape__': obj.shape,
                '__dtype__': obj.dtype.name}
         out['value'] = obj.flatten().tolist()
+
         if 'complex' in obj.dtype.name:
             out['value'] = [(obj.real).tolist(), (obj.imag).tolist()]
+        elif obj.dtype.name == 'object':
+            out['value'] = [encode4js(i, grouplist=grouplist) for i in out['value']]
+
         return out
     elif isinstance(obj, (np.float, np.int)):
         return float(obj)
@@ -98,6 +102,10 @@ def decode4js(obj, grouplist=None):
             re = np.fromiter(obj['value'][0], dtype='double')
             im = np.fromiter(obj['value'][1], dtype='double')
             out = re + 1j*im
+        elif obj['__dtype__'].startswith('object'):
+            val = [decode4js(v, grouplist=grouplist) for v in obj['value']]
+            out = np.array(val,  dtype=obj['__dtype__'])
+
         else:
             out = np.fromiter(obj['value'], dtype=obj['__dtype__'])
         out.shape = obj['__shape__']

--- a/lib/utils/jsonutils.py
+++ b/lib/utils/jsonutils.py
@@ -8,14 +8,21 @@ from larch import isParameter, Parameter, isgroup, Group
 
 import numpy as np
 
-def encode4js(obj):
+def encode4js(obj, grouplist=None):
     """return an object ready for json encoding.
     has special handling for many Python types
       numpy array
       complex numbers
       Larch Groups
       Larch Parameters
+
+    grouplist: list of subclassed Groups to assist reconstucting the object
     """
+    _groups = {}
+    if grouplist is not None:
+        for g in grouplist:
+            _groups[g.__name__] = g
+
     if isinstance(obj, np.ndarray):
         out = {'__class__': 'Array', '__shape__': obj.shape,
                '__dtype__': obj.dtype.name}
@@ -30,9 +37,12 @@ def encode4js(obj):
     elif isinstance(obj, np.complex):
         return {'__class__': 'Complex', 'value': (obj.real, obj.imag)}
     elif isgroup(obj):
-        out = {'__class__': 'Group'}
+        classname = 'Group'
+        if obj.__class__.__name__ in _groups:
+            classname = obj.__class__.__name__
+        out = {'__class__': classname}
         for item in dir(obj):
-            out[item] = encode4js(getattr(obj, item))
+            out[item] = encode4js(getattr(obj, item), grouplist=grouplist)
         return out
     elif isParameter(obj):
         out = {'__class__': 'Parameter'}
@@ -46,49 +56,64 @@ def encode4js(obj):
         ctype = 'List'
         if isinstance(obj, tuple):
             ctype = 'Tuple'
-        val = [encode4js(item) for item in obj]
+        val = [encode4js(item, grouplist=grouplist) for item in obj]
         return {'__class__': ctype, 'value': val}
     elif isinstance(obj, dict):
         out = {'__class__': 'Dict'}
         for key, val in obj.items():
-            out[encode4js(key)] = encode4js(val)
+            out[encode4js(key, grouplist=grouplist)] = encode4js(val, grouplist=grouplist)
         return out
     elif callable(obj):
         return {'__class__': 'Method', '__name__': repr(obj)}
 
     return repr(obj)
 
-def decode4js(obj):
+def decode4js(obj, grouplist=None):
     """
     return decoded Python object from encoded object.
-    """
+
+    grouplist: list of subclassed Groups to assist reconstucting the object
+   """
+    if not isinstance(obj, dict):
+        return obj
     out = obj
-    if isinstance(obj, dict):
-        classname = obj.pop('__class__', None)
-        if classname is None:
-            return obj
-        elif classname == 'Complex':
-            out = obj['value'][0] + 1j*obj['value'][1]
-        elif classname in ('List', 'Tuple'):
-            out = []
-            for item in obj['value']:
-                out.append(decode4js(item))
-            if classname == 'Tuple':
-                out = tuple(out)
-        elif classname == 'Array':
-            if obj['__dtype__'].startswith('complex'):
-                re = np.fromiter(obj['value'][0], dtype='double')
-                im = np.fromiter(obj['value'][1], dtype='double')
-                out = re + 1j*im
+    classname = obj.pop('__class__', None)
+    if classname is None:
+        return obj
+
+    _groups = {'Group': Group, 'Parameter': Parameter}
+    if grouplist is not None:
+        for g in grouplist:
+            _groups[g.__name__] = g
+    if classname == 'Complex':
+        out = obj['value'][0] + 1j*obj['value'][1]
+    elif classname in ('List', 'Tuple'):
+        out = []
+        for item in obj['value']:
+            out.append(decode4js(item, grouplist))
+        if classname == 'Tuple':
+            out = tuple(out)
+    elif classname == 'Array':
+        if obj['__dtype__'].startswith('complex'):
+            re = np.fromiter(obj['value'][0], dtype='double')
+            im = np.fromiter(obj['value'][1], dtype='double')
+            out = re + 1j*im
+        else:
+            out = np.fromiter(obj['value'], dtype=obj['__dtype__'])
+        out.shape = obj['__shape__']
+    elif classname in ('Dict', 'dict'):
+        out = {}
+        for key, val in obj.items():
+            out[key] = decode4js(val, grouplist)
+    elif classname in _groups:
+        out = {}
+        for key, val in obj.items():
+            if (isinstance(val, dict) and
+                val.get('__class__', None) == 'Method' and
+                val.get('__name__', None) is not None):
+                pass  # ignore class methods for subclassed Groups
             else:
-                out = np.fromiter(obj['value'], dtype=obj['__dtype__'])
-            out.shape = obj['__shape__']
-        elif classname in ('Dict', 'Parameter', 'Group'):
-            out = {}
-            for key, val in obj.items():
-                out[key] = decode4js(val)
-            if classname == 'Parameter':
-                out = Parameter(**out)
-            elif classname == 'Group':
-                out = Group(**out)
+                out[key] = decode4js(val, grouplist)
+        out = _groups[classname](**out)
+
     return out

--- a/lib/utils/jsonutils.py
+++ b/lib/utils/jsonutils.py
@@ -66,7 +66,7 @@ def encode4js(obj, grouplist=None):
     elif callable(obj):
         return {'__class__': 'Method', '__name__': repr(obj)}
 
-    return repr(obj)
+    return obj
 
 def decode4js(obj, grouplist=None):
     """

--- a/lib/utils/strutils.py
+++ b/lib/utils/strutils.py
@@ -125,11 +125,12 @@ def fix_filename(s):
             idot = t.find('.')
             t = "%s_%s" % (t[:idot], t[idot+1:])
     return t
+
 def fix_varname(s):
     """fix string to be a 'good' variable name."""
     t = str(s).translate(TRANS_VARS)
     if t[0] not in VALID_CHARS1:
-        t[0] = '_'
+        t = '_%s' % t
     while t.endswith('_'):
         t = t[:-1]
     return t

--- a/plugins/io/athena_project.py
+++ b/plugins/io/athena_project.py
@@ -12,8 +12,7 @@ from glob import glob
 
 import numpy as np
 from larch import Group
-from larch.utils.strutils import bytes2str
-from larch_plugins.io import fix_varname
+from larch.utils.strutils import bytes2str, fix_varname
 
 if sys.version[0] == '2':
     from string import maketrans
@@ -106,7 +105,7 @@ def read_athena(filename, match=None, do_preedge=True,
         raise ValueError("%s '%s': file is too old to read" % (ERR_MSG, filename))
 
     for t in lines:
-        if t.startswith('#') or len(t) < 2:
+        if t.startswith('#') or len(t) < 2 or 'undef' in t:
             continue
         key = t.split(' ')[0].strip()
         key = key.replace('$', '').replace('@', '')
@@ -126,7 +125,7 @@ def read_athena(filename, match=None, do_preedge=True,
     out = Group()
     out.__doc__ = """XAFS Data from Athena Project File %s""" % (filename)
     for dat in athenagroups:
-        label = dat['name']
+        label = dat.get('name', 'unknown')
         this = Group(athena_id=label, energy=dat['x'], mu=dat['y'],
                      bkg_params=Group(), fft_params = Group(),
                      athena_params=Group())

--- a/plugins/io/save_restore.py
+++ b/plugins/io/save_restore.py
@@ -223,13 +223,13 @@ def save(fname,  *args, **kws):
     ----------
        fname   name of output save file.
        args    list of groups, data items to be saved.
-]
+
    See Also:  restore()
     """
     _larch = kws.get('_larch', None)
     isgroup =  _larch.symtable.isgroup
 
-    expr = getattr(_larch, 'this_expr', '_unknown_')
+    expr = getattr(_larch, 'this_expr', 'save(foo)')
 
     buff = ["#Larch Save File: v1.0",
             "#save.date: %s" % time.strftime('%Y-%m-%d %H:%M:%S'),
@@ -237,29 +237,16 @@ def save(fname,  *args, **kws):
             "#save.nitems:  %i" % len(args)]
 
     names = []
-    print expr
     if expr.startswith('save('):
         names = [a.strip() for a in expr[5:-1].split(',')]
     names.pop(0)
-    print names
-
     if len(names) < len(args):
         names.extend(["_unknown_"]*(len(args) - len(names)))
 
     for key, arg in zip(names, args):
-        print(" --> ", key, arg, type(arg) )
-
         buff.append("# %s " % key)
-        jsready =  encode4js(arg)
-        for key, val in jsready.items():
-            print key, ' : ', val
-        # print(" --> " , arg, isgroup(arg), encode4js(arg))
-
         buff.append(json.dumps(encode4js(arg)))
     buff.append("")
-
-
-
     with open(fname, "w") as fh:
         fh.write("\n".join(buff))
 

--- a/plugins/io/save_restore.py
+++ b/plugins/io/save_restore.py
@@ -52,10 +52,24 @@ def save(fname,  *args, **kws):
 
 
 @ValidateLarchPlugin
-def restore(fname, _larch=None):
-    """restore data from a json Larch Save file
-    returns a group of data
+def restore(fname, top_level=True, _larch=None):
+    """restore data from a json Larch save file
+
+    Arguments
+    ---------
+    top_level  bool  whether to restore to _main [True]
+
+
+    Returns
+    -------
+    None   with `top_level=True` or group with `top_level=False`
+
+    Notes
+    -----
+    1.  With top_level=False, a new group containing the
+        recovered data will be returned.
     """
+
     grouplist = _larch.symtable._sys.saverestore_groups
 
     datalines = open(fname, 'r').readlines()
@@ -86,7 +100,13 @@ def restore(fname, _larch=None):
         else:
             val = decode4js(json.loads(line), grouplist)
             setattr(out, varnames[-1], val)
-    setattr(out, '_restore_data_', header)
+    setattr(out, '_restore_metadata_', header)
+
+    if top_level:
+        _main = _larch.symtable
+        for objname in dir(out):
+            setattr(_main, objname, getattr(out, objname))
+        return
     return out
 
 def registerLarchPlugin():

--- a/plugins/io/save_restore.py
+++ b/plugins/io/save_restore.py
@@ -1,217 +1,14 @@
-import inspect
+
 import json
 import time
 import numpy as np
-import h5py
+
+from collections import OrderedDict
+
 from larch import Group, Parameter, isParameter
 from larch import ValidateLarchPlugin
-from larch.utils import fixName
 from larch.utils.jsonutils import encode4js, decode4js
 from larch_plugins.io import fix_varname
-
-
-class H5PySaveFile(object):
-    def __init__(self, fname, _larch=None):
-        self.fname = fname
-        self._larch = _larch
-        self.symtable = _larch.symtable
-        self.isgroup =  _larch.symtable.isgroup
-        self._searched = []
-        self._subgroups = []
-        self._ids  = []
-        self._objs = []
-        self.out = {}
-        self.savednames = []
-
-    def search(self, group):
-        """search for objects to save,
-        populating self.out
-        """
-        if len(self._ids) == 0:
-            return
-
-        for nam in dir(group):
-            self._searched.append(group)
-            obj = getattr(group, nam)
-            if (id(obj) in self._ids and
-                obj not in self.out.values()):
-                self.out[nam] = obj
-                self._ids.remove(id(obj))
-                self._objs.remove(obj)
-            if (self.isgroup(obj) and
-                obj not in self._searched and
-                obj not in self._subgroups):
-                self._subgroups.append(obj)
-        if group in self._subgroups:
-            self._subgroups.remove(group)
-        for group in self._subgroups:
-            self.search(group)
-
-    def add_h5group(self, group, name, dat=None, attrs=None):
-        """add an hdf5 group to group"""
-        g = group.create_group(name)
-
-        if isinstance(dat, dict):
-            for key, val in dat.items():
-                g[key] = val
-        if isinstance(attrs, dict):
-            for key, val in attrs.items():
-                g.attrs[key] = val
-        return g
-
-    def add_h5dataset(self, group, name, data, attrs=None, **kws):
-        """creata an hdf5 dataset"""
-        try:
-            d = group.create_dataset(name, data=data, **kws)
-        except TypeError:
-            d = group.create_dataset(name, data=repr(data), **kws)
-        if isinstance(attrs, dict):
-            for key, val in attrs.items():
-                d.attrs[key] = val
-        return d
-
-    def add_data(self, group, name, data):
-        name = fix_varname(name)
-        if self.isgroup(data):
-            g = self.add_h5group(group, name,
-                                 attrs={'larchtype': 'group',
-                                        'class': data.__class__.__name__})
-            for comp in dir(data):
-                self.add_data(g, comp, getattr(data, comp))
-        elif isinstance(data, (list, tuple)):
-            dtype = 'list'
-            if isinstance(data, tuple): dtype = 'tuple'
-            g = self.add_h5group(group, name, attrs={'larchtype': dtype})
-            for ix, comp in enumerate(data):
-                iname = 'item%i' % ix
-                self.add_data(g, iname, comp)
-        elif isinstance(data, dict):
-            g = self.add_h5group(group, name, attrs={'larchtype': 'dict'})
-            for key, val in data.items():
-                self.add_data(g, key, val)
-        elif isParameter(data):
-            g = self.add_h5group(group, name, attrs={'larchtype': 'parameter'})
-            self.add_h5dataset(g, 'json', data.asjson())
-        else:
-            d = self.add_h5dataset(group, name, data)
-
-    def save(self, *args):
-        self._ids  = [id(a) for a in args]
-        self._objs = list(args)
-        self.search(self.symtable)
-        self.fh = h5py.File(self.fname, 'a')
-        try:
-            self.fh.attrs['datatype'] = 'LarchSaveFile'
-            self.fh.attrs['version'] = '1.0.0'
-        except:
-            pass
-        for nam, obj in self.out.items():
-            onam = getattr(obj, '__name__', None)
-            if onam is not None:
-                nam = onam
-            self.add_data(self.fh, nam, obj)
-
-        for obj in self._objs:
-            nam = getattr(obj, '__name__', hex(id(obj)))
-            if nam.startswith('0x'):
-                nam = 'obj_%s' % nam[2:]
-            self.add_data(self.fh, nam, obj)
-
-        self.fh.close()
-
-@ValidateLarchPlugin
-def save_h5(fname,  *args, **kws):
-    """save groups and data into a portable, hdf5 file
-
-    save(fname, arg1, arg2, ....)
-
-    Parameters
-    ----------
-       fname   name of output save file.
-       args    list of groups, data items to be saved.
-
-   See Also:  restore()
-    """
-    _larch = kws.get('_larch', None)
-
-    saver = H5PySaveFile(fname, _larch=_larch)
-    saver.save(*args)
-
-@ValidateLarchPlugin
-def restore_h5(fname,  group=None, _larch=None):
-    """restore groups and data from an hdf5 Larch Save file
-
-    restore(fname, group=None)
-
-    Parameters
-    ----------
-       fname   name of output Larch save file (required)
-       group   top-level group to put data in [None]
-
-   Returns
-   -------
-       top-level grouop containing restored subgroups and data.
-
-   If group is None, a group will be created and returned.
-
-   See Also:  save()
-   """
-    symtable = _larch.symtable
-    msg  = _larch.writer.write
-    fh = h5py.File(fname, 'r')
-
-    if fh.attrs.get('datatype', None) != 'LarchSaveFile':
-        msg("File  '%s' is not a valid larch save file\n" % fname)
-        return
-    create_group = _larch.symtable.create_group
-
-    from larch_plugins.xafs import (FeffPathGroup, FeffDatFile,
-                                    FeffitDataSet, TransformGroup)
-
-    def make_group(h5group):
-        creators = {'TransformGroup': TransformGroup,
-                    'FeffDatFile':    FeffDatFile,
-                    'FeffitDataSet':  FeffitDataSet,
-                    'FeffPathGroup':  FeffPathGroup}
-        gtype = h5group.attrs.get('class', None)
-        return creators.get(gtype, create_group)(_larch=_larch)
-
-    def get_component(val):
-        if isinstance(val, h5py.Group):
-            ltype = val.attrs.get('larchtype', None)
-            if ltype == 'group':
-                me = make_group(val)
-                for skey, sval in val.items():
-                    setattr(me, skey, get_component(sval))
-                return me
-            elif ltype == 'parameter':
-                kws = json.loads(val['json'].value)
-                if kws['expr'] is not None:
-                    kws.pop('val')
-                kws['_larch'] = _larch
-                return Parameter(**kws)
-            elif ltype in ('list', 'tuple'):
-                me = []
-                for skey, sval in  val.items():
-                    me.append(get_component(sval))
-                if ltype == 'tuple':
-                    me = tuple(me)
-                return me
-            elif ltype == 'dict':
-                me = {}
-                for skey, sval in  val.items():
-                    me[skey] = get_component(sval)
-                return me
-        elif isinstance(val, h5py.Dataset):
-            return val.value
-
-    # walk through items in hdf5 save file
-    if group is None:
-        group = create_group()
-    for  key, val in fh.items():
-        setattr(group, key, get_component(val))
-    fh.close()
-    return group
 
 @ValidateLarchPlugin
 def save(fname,  *args, **kws):
@@ -230,8 +27,11 @@ def save(fname,  *args, **kws):
     isgroup =  _larch.symtable.isgroup
 
     expr = getattr(_larch, 'this_expr', 'save(foo)')
+    expr = expr.replace('\n', ' ').replace('\r', ' ')
 
-    buff = ["#Larch Save File: v1.0",
+    grouplist = _larch.symtable._sys.saverestore_groups[:]
+
+    buff = ["#Larch Save File: 1.0",
             "#save.date: %s" % time.strftime('%Y-%m-%d %H:%M:%S'),
             "#save.command: %s" % expr,
             "#save.nitems:  %i" % len(args)]
@@ -243,21 +43,51 @@ def save(fname,  *args, **kws):
     if len(names) < len(args):
         names.extend(["_unknown_"]*(len(args) - len(names)))
 
-    for key, arg in zip(names, args):
-        buff.append("# %s " % key)
-        buff.append(json.dumps(encode4js(arg)))
+    for name, arg in zip(names, args):
+        buff.append("#=> %s" % name)
+        buff.append(json.dumps(encode4js(arg, grouplist=grouplist)))
     buff.append("")
     with open(fname, "w") as fh:
         fh.write("\n".join(buff))
 
 
 @ValidateLarchPlugin
-def restore(fname,  group=None, _larch=None):
-    """restore groups and data from a json Larch Save file
+def restore(fname, _larch=None):
+    """restore data from a json Larch Save file
+    returns a group of data
     """
+    grouplist = _larch.symtable._sys.saverestore_groups
 
-    with open(fname, "w") as fh:
-        fh.write("\n".join(buff))
+    datalines = open(fname, 'r').readlines()
+    line1 = datalines.pop(0)
+    if not line1.startswith("#Larch Save File:"):
+        raise ValueError("%s is not a valid Larch save file" % fname)
+    version_string = line1.split(':')[1].strip()
+    version_info = [s for s in version_string.split('.')]
+
+    ivar = 0
+    header = {'version': version_info}
+    varnames = []
+    gname = fix_varname('restore_%s' % fname)
+    out = Group(name=gname)
+    for line in datalines:
+        line = line[:-1]
+        if line.startswith('#save.'):
+            key, value = line[6:].split(':', 1)
+            value = value.strip()
+            if key == 'nitems': value = int(value)
+            header[key] = value
+        elif line.startswith('#=>'):
+            name = fix_varname(line[4:].strip())
+            ivar += 1
+            if name in (None, 'None', '__unknown__') or name in varnames:
+                name = 'var_%5.5i' % (ivar)
+            varnames.append(name)
+        else:
+            val = decode4js(json.loads(line), grouplist)
+            setattr(out, varnames[-1], val)
+    setattr(out, '_restore_data_', header)
+    return out
 
 def registerLarchPlugin():
-    return ('_io', { 'save': save})
+    return ('_io', { 'save': save, 'restore': restore})

--- a/plugins/io/save_restore.py
+++ b/plugins/io/save_restore.py
@@ -21,7 +21,7 @@ def save(fname,  *args, **kws):
        fname   name of output save file.
        args    list of groups, data items to be saved.
 
-   See Also:  restore()
+    See Also:  restore()
     """
     _larch = kws.get('_larch', None)
     isgroup =  _larch.symtable.isgroup
@@ -39,7 +39,10 @@ def save(fname,  *args, **kws):
     names = []
     if expr.startswith('save('):
         names = [a.strip() for a in expr[5:-1].split(',')]
-    names.pop(0)
+    try:
+        names.pop(0)
+    except:
+        pass
     if len(names) < len(args):
         names.extend(["_unknown_"]*(len(args) - len(names)))
 

--- a/plugins/xafs/diffkk.py
+++ b/plugins/xafs/diffkk.py
@@ -320,6 +320,8 @@ def diffkk(energy=None, mu=None, z=None, edge='K', mback_kws=None, _larch=None, 
     """
     return diffKKGroup(energy=energy, mu=mu, z=z, mback_kws=mback_kws, _larch=_larch)
 
+def registerLarchGroups():
+    return (diffKKGroup,)
 
 def registerLarchPlugin(): # must have a function with this name!
     return ('_xafs', { 'diffkk': diffkk })

--- a/plugins/xafs/feffdat.py
+++ b/plugins/xafs/feffdat.py
@@ -489,6 +489,9 @@ def feffpath(filename=None, _larch=None, label=None, s02=None,
                          sigma2=sigma2, third=third, fourth=fourth,
                          _larch=_larch)
 
+def registerLarchGroups():
+    return (FeffDatFile, FeffPathGroup)
+
 def registerLarchPlugin():
     return ('_xafs', {'feffpath': feffpath,
                       'path2chi': _path2chi,

--- a/plugins/xafs/feffit.py
+++ b/plugins/xafs/feffit.py
@@ -655,6 +655,9 @@ def feffit_report(result, min_correl=0.1, with_paths=True,
     out.append('='*len(topline))
     return '\n'.join(out)
 
+def registereLarchGroups():
+    return (TransformGroup, FeffitDataSet)
+
 def registerLarchPlugin():
     return ('_xafs', {'feffit': feffit,
                       'feffit_dataset': feffit_dataset,

--- a/plugins/xafs/feffrunner.py
+++ b/plugins/xafs/feffrunner.py
@@ -236,6 +236,8 @@ def feffrunner(feffinp=None, verbose=True, repo=None, _larch=None, **kws):
     """
     return FeffRunner(feffinp=feffinp, verbose=verbose, repo=repo, _larch=_larch)
 
+def registerLarchGroups():
+    return (FeffRunner,)
 
 def registerLarchPlugin(): # must have a function with this name!
     return ('_xafs', { 'feffrunner': feffrunner })

--- a/plugins/xrf/mca.py
+++ b/plugins/xrf/mca.py
@@ -323,5 +323,8 @@ def create_mca(counts=None, nchans=2048, offset=0, slope=0, quad=0,
                live_time=live_time, input_counts=input_counts,
                tau=tau, **kws)
 
+def registerLarchGroups():
+    return (MCA,)
+
 def registerLarchPlugin():
     return ('_xrf', {'create_mca': create_mca})

--- a/plugins/xrf/roi.py
+++ b/plugins/xrf/roi.py
@@ -81,7 +81,7 @@ class ROI(Group):
                 self.right == getattr(other, 'right', None) and
                 self.bgr_width == getattr(other, 'bgr_width', None) )
 
-    def __ne__(self, other): return not self.__eq__(other) 
+    def __ne__(self, other): return not self.__eq__(other)
     def __lt__(self, other): return self.left <  getattr(other, 'left', None)
     def __le__(self, other): return self.left <= getattr(other, 'left', None)
     def __gt__(self, other): return self.left >  getattr(other, 'left', None)
@@ -151,7 +151,8 @@ def initializeLarchPlugin(_larch=None):
         mod = getattr(_larch.symtable, '_xrf')
         mod.__doc__ = MODDOC
 
+def registerLarchGroups():
+    return (ROI,)
+
 def registerLarchPlugin():
     return ('_xrf', {'create_roi': create_roi})
-
-


### PR DESCRIPTION
This is a re-write of save() / restore() to use JSON instead of HDF5, which better support sub-classed groups like FeffPathGroup. 

A side effect of this PR is that plugins can now have a `registerLarchGroups()` function (simply returning a list or tuple of classes that should be able to be save()d and restore()d fully).   This is PR includes this function for many plugins. 

This addresses #163 

