### PR TITLE
Minor updates for XRD and non-XRD tomography maps

### DIFF
--- a/examples/xafs/mback_normalization.lar
+++ b/examples/xafs/mback_normalization.lar
@@ -1,0 +1,8 @@
+data=read_ascii('../xafsdata/cu_10k.xmu')
+
+mback(data, z=29, edge='K', order=5, fit_erfc=False)
+
+plot(data.energy, data.fpp, label=r'$\mu$', new=True)
+
+plot(data.energy, data.f2, xlabel='Energy (eV)',
+     ylabel=r'$\mu(E), f_2(E) $', label=r'$f_2$',  show_legend=True)

--- a/modules/xafs_plots.lar
+++ b/modules/xafs_plots.lar
@@ -16,8 +16,16 @@ Plotting macros for XAFS data sets and fits
 """
 
 # common XAFS plot labels
-def __chir_label__(show_mag, show_real, show_imag, kweight):
-    "private method: determine y label for chi(R) plot"
+def chirlab(kweight, show_mag=True, show_real=False, show_imag=False):
+    """generate chi(R) label for a kweight
+
+    Arguments
+    ----------
+     kweight      k-weight to use (required)
+     show_mag     bool whether to plot |chi(R)| [True]
+     show_real    bool whether to plot Re[chi(R)] [False]
+     show_imag    bool whether to plot Im[chi(R)] [False]
+    """
     ylab = []
     if show_mag:  ylab.append(plotlabels.chirmag)
     if show_real: ylab.append(plotlabels.chirre)
@@ -38,7 +46,7 @@ plotlabels = group(k       = r'$k \rm\,(\AA^{-1})$',
                    chirim  = r'${{\rm Im}}[\chi(R)] \rm\,(\AA^{{-{0:g}}})$',
                    chirpha = r'${{\rm Phase}}[\chi(R)] \rm\,(\AA^{{-{0:g}}})$',
                    e0color = '#B2B282',
-                   chirlab = __chir_label__)
+                   chirlab = chirlab)
 
 
 def plot_mu(dgroup, norm=False, deriv=False, show_pre=False, show_post=False,
@@ -264,7 +272,7 @@ def plot_chir(dgroup, show_mag=True, show_real=False, show_imag=False,
                 title=dgroup.filename, zorder=20, xmax=rmax,
                 xlabel=plotlabels.r, new=new)
 
-    ylabel = plotlabels.chirlab(show_mag, show_real, show_imag, kweight)
+    ylabel = plotlabels.chirlab(kweight, show_mag=show_mag, show_real=show_real, show_imag=show_imag)
     opts['ylabel'] = ylabel
 
     if label is None:
@@ -330,7 +338,7 @@ def plot_chifit(dataset, kmin=0, kmax=None, kweight=None, rmax=None,
     # show chi(R) in next plot window
     opts['win'] = win+1
 
-    ylabel = plotlabels.chirlab(show_mag, show_real, show_imag, kweight)
+    ylabel = plotlabels.chirlab(kweight, show_mag=show_mag, show_real=show_real, show_imag=show_imag)
     opts.update({'xlabel': plotlabels.r, 'ylabel': ylabel,
                  'xmax': rmax, 'new': new})
 
@@ -417,7 +425,7 @@ def plot_path_r(dataset, ipath, rmax=None, offset=0, label=None,
         label = 'path %i' % (ipath)
     #endif
     kweight =dataset.transform.kweight
-    ylabel = plotlabels.chirlab(show_mag, show_real, show_imag, kweight)
+    ylabel = plotlabels.chirlab(kweight, show_mag=show_mag, show_real=show_real, show_imag=show_imag)
 
     opts.update({'xlabel': plotlabels.r, 'ylabel': ylabel,
                  'xmax': rmax, 'new': new})
@@ -491,7 +499,7 @@ def plot_paths_r(dataset, offset=-0.5, rmax=None, show_mag=True, show_real=False
     kweight = dataset.transform.kweight
     model = dataset.model
 
-    ylabel = plotlabels.chirlab(show_mag, show_real, show_imag, kweight)
+    ylabel = plotlabels.chirlab(kweight, show_mag=show_mag, show_real=show_real, show_imag=show_imag)
 
     opts.update({'xlabel': plotlabels.r, 'ylabel': ylabel,
                  'xmax': rmax, 'new': new})

--- a/plugins/diFFit/XRD1Dviewer.py
+++ b/plugins/diFFit/XRD1Dviewer.py
@@ -408,7 +408,7 @@ class SelectSavingData(wx.Dialog):
         dlg = wx.FileDialog(self, 'Save file as...',
                            defaultDir=dfltDIR,
                            wildcard=wildcards,
-                           style=wx.SAVE|wx.OVERWRITE_PROMPT)
+                           style=wx.FD_SAVE|wx.FD_OVERWRITE_PROMPT)
 
         path, save = None, False
         if dlg.ShowModal() == wx.ID_OK:
@@ -2246,7 +2246,7 @@ class Viewer1DXRD(wx.Panel):
         dlg = wx.FileDialog(self, 'Save data as...',
                            defaultDir=os.getcwd(),
                            wildcard=wildcards,
-                           style=wx.SAVE|wx.OVERWRITE_PROMPT)
+                           style=wx.FD_SAVE|wx.FD_OVERWRITE_PROMPT)
 
         path, save = None, False
         if dlg.ShowModal() == wx.ID_OK:

--- a/plugins/diFFit/XRD1Dviewer.py
+++ b/plugins/diFFit/XRD1Dviewer.py
@@ -321,11 +321,15 @@ class diFFit1DFrame(wx.Frame):
                 index = dlg.slct_1Ddata.GetSelection()
                 filename = dlg.File.GetValue()
                 calfile = dlg.Poni.GetValue() if len(dlg.Poni.GetValue()) > 0 else None
+                unts = dlg.ch_units.GetSelection()
             dlg.Destroy()
 
         if okay:
             savdat = xrdv.xy_data[index]
-            save1D(filename, savdat.q, savdat.I, calfile=calfile)
+            if unts == 1: ## 2theta
+                save1D(filename, savdat.twth, savdat.I, xaxis_unit='2th', calfile=calfile)            
+            else:         ## q
+                save1D(filename, savdat.q, savdat.I, xaxis_unit='q', calfile=calfile)
 
 
 class SelectSavingData(wx.Dialog):
@@ -350,6 +354,17 @@ class SelectSavingData(wx.Dialog):
         datasizer.Add(self.slct_1Ddata, flag=wx.EXPAND|wx.TOP,    border=8)
 
 #         self.slct_1Ddata.Bind(wx.EVT_LISTBOX,  None  )
+
+        ## SELECT UNITS
+        self.ch_units = wx.Choice(panel, choices=[u'q (\u212B\u207B\u00B9)',u'2\u03B8 (\u00B0)'])
+        ttl_units     = SimpleText(panel, label='Units:')
+        
+        hsizer = wx.BoxSizer(wx.HORIZONTAL)
+        hsizer.Add(ttl_units,           flag=wx.RIGHT,            border=5)
+        hsizer.Add(self.ch_units,       flag=wx.RIGHT,            border=5)
+        
+        unitsizer = wx.BoxSizer(wx.VERTICAL)
+        unitsizer.Add(hsizer,           flag=wx.TOP,              border=5)
 
 
         ## SAVE TO FILE
@@ -389,6 +404,8 @@ class SelectSavingData(wx.Dialog):
 
         mainsizer.AddSpacer(8)
         mainsizer.Add(datasizer, flag=wx.LEFT, border=8)
+        mainsizer.AddSpacer(15)
+        mainsizer.Add(unitsizer, flag=wx.LEFT, border=8)
         mainsizer.AddSpacer(15)
         mainsizer.Add(filesizer, flag=wx.LEFT, border=8)
         mainsizer.AddSpacer(15)

--- a/plugins/diFFit/XRD1Dviewer.py
+++ b/plugins/diFFit/XRD1Dviewer.py
@@ -1736,6 +1736,10 @@ class Viewer1DXRD(wx.Panel):
         vbox.Add(addbtns,flag=wx.ALL,border=10)
         vbox.Add(dattools,flag=wx.ALL,border=10)
         vbox.Add(ciftools,flag=wx.ALL,border=10)
+        
+        self.ch_xaxis.SetSelection(0)
+        self.ch_yaxis.SetSelection(0)
+        
         return vbox
 
     def RightSidePanel(self,panel):
@@ -2038,6 +2042,7 @@ class Viewer1DXRD(wx.Panel):
 
         self.ch_xaxis.Enable()
         self.ch_yaxis.Enable()
+
         if data:
             self.val_scale.Enable()
             self.btn_reset.Enable()

--- a/plugins/diFFit/XRD2Dviewer.py
+++ b/plugins/diFFit/XRD2Dviewer.py
@@ -455,7 +455,7 @@ class diFFit2DFrame(wx.Frame):
         dlg = wx.FileDialog(self, 'Save image as...',
                            defaultDir=os.getcwd(),
                            wildcard=wildcards,
-                           style=wx.SAVE|wx.OVERWRITE_PROMPT)
+                           style=wx.FD_SAVE|wx.FD_OVERWRITE_PROMPT)
 
         path, save = None, False
         if dlg.ShowModal() == wx.ID_OK:
@@ -491,7 +491,7 @@ class diFFit2DFrame(wx.Frame):
                 dlg = wx.FileDialog(self, 'Save file as...',
                                    defaultDir=os.getcwd(),
                                    wildcard=wildcards,
-                                   style=wx.SAVE|wx.OVERWRITE_PROMPT)
+                                   style=wx.FD_SAVE|wx.FD_OVERWRITE_PROMPT)
                 if dlg.ShowModal() == wx.ID_OK:
                     filename = dlg.GetPath().replace('\\', '/')
                     attrs.update({'file':filename})

--- a/plugins/diFFit/XRD2Dviewer.py
+++ b/plugins/diFFit/XRD2Dviewer.py
@@ -163,15 +163,13 @@ class diFFit2DFrame(wx.Frame):
                            defaultDir=os.getcwd(),
                            wildcard=wildcards, style=wx.FD_OPEN)
 
-        path, read = None, False
+        path, read = '', False
         if dlg.ShowModal() == wx.ID_OK:
             read = True
             path = dlg.GetPath().replace('\\', '/')
         dlg.Destroy()
         
         if read:
-            
-            
             print('Reading file: %s' % path)
             try:
                 try:
@@ -183,23 +181,26 @@ class diFFit2DFrame(wx.Frame):
                 return
 
             iname = os.path.split(path)[-1]
+            self.plot2Dxrd(iname,image,path=path)
 
-            self.write_message('Displaying image: %s' % iname, panel=0)
-            self.open_image.append(XRDImg(label=iname, path=path, image=image))
+    def plot2Dxrd(self,iname,image,path=''):
 
-            name_images = [image.label for image in self.open_image]
-            self.ch_img.Set(name_images)
-            self.ch_img.SetStringSelection(iname)
+        self.write_message('Displaying image: %s' % iname, panel=0)
+        self.open_image.append(XRDImg(label=iname, path=path, image=image))
 
-            self.raw_img = self.open_image[-1].get_image()
-            self.displayIMAGE()
-                
-            if self.open_image[-1].frames > 1:
-                self.frmsldr.SetRange(0,(self.open_image[-1].frames-1))
-                self.frmsldr.SetValue(self.open_image[-1].i)
-            else:
-                self.frmsldr.Disable()
-                for btn in self.frm_btn: btn.Disable()
+        name_images = [image.label for image in self.open_image]
+        self.ch_img.Set(name_images)
+        self.ch_img.SetStringSelection(iname)
+
+        self.raw_img = self.open_image[-1].get_image()
+        self.displayIMAGE()
+            
+        if self.open_image[-1].frames > 1:
+            self.frmsldr.SetRange(0,(self.open_image[-1].frames-1))
+            self.frmsldr.SetValue(self.open_image[-1].i)
+        else:
+            self.frmsldr.Disable()
+            for btn in self.frm_btn: btn.Disable()
 
             
     def changeFRAME(self,flag='slider',event=None):
@@ -1019,7 +1020,7 @@ class XRDImg(Group):
     mkak 2017.08.15
     '''
 
-    def __init__(self, label=None, path=None, type='tiff', image=None):
+    def __init__(self, label=None, path='', type='tiff', image=None):
 
         self.label = label
         self.path  = path
@@ -1038,7 +1039,6 @@ class XRDImg(Group):
         shp = np.shape(self.image)
         if len(shp) == 2:
             self.image = np.reshape(self.image,(1,shp[0],shp[1]))
-
         self.frames = np.shape(self.image)[0]
         self.i = 0 if self.frames < 4 else int(self.frames)/2
 

--- a/plugins/wx/mapviewer.py
+++ b/plugins/wx/mapviewer.py
@@ -722,14 +722,14 @@ class TomographyPanel(GridPanel):
        
         self.enable_options()
         self.set_det_choices(xrmmap)
+        
         try:
             self.npts = len(self.file.get_pos('fine x', mean=True))       
         except:
             self.npts = len(self.file.get_pos('x', mean=True))
-        try:
-            center = self.xrmmap['tomo/center'][...]
-        except:
-            center = self.npts/2.
+        
+        center = self.file.get_tomo_center()
+        
         self.center_value.SetRange(-0.5*self.npts,1.5*self.npts)
         self.center_value.SetValue(center)
         self.plotSELECT()

--- a/plugins/wx/mapviewer.py
+++ b/plugins/wx/mapviewer.py
@@ -2407,22 +2407,22 @@ class MapViewerFrame(wx.Frame):
         displays 2D XRD pattern in diFFit viewer
         '''
         flptyp = 'vertical' if flip is True else False
+        poni = ''
         if self.xrddisplay2D is None:
             try:
                 poni = bytes2str(self.current_file.xrmmap['xrd1D'].attrs['calfile'])
             except:
-                poni = ''
+                pass
             if not os.path.exists(poni): poni = None
             self.xrddisplay2D = diFFit2DFrame(_larch=self.larch,flip=flptyp,
                                               xrd1Dviewer=self.xrddisplay1D,
                                               ponifile=poni)
         try:
-            self.xrddisplay2D.plot2Dxrd(map,title)
+            self.xrddisplay2D.plot2Dxrd(title,map)
         except PyDeadObjectError:
             self.xrddisplay2D = diFFit2DFrame(_larch=self.larch,flip=flptyp,
-                                              xrd1Dviewer=self.xrddisplay1D,
-                                              ponifile=poni)
-            self.xrddisplay2D.plot2Dxrd(map,title)
+                                              xrd1Dviewer=self.xrddisplay1D)
+            self.xrddisplay2D.plot2Dxrd(title,map)
         self.xrddisplay2D.Show()
         self.xrddisplay2D.displayCAKE()
 

--- a/plugins/wx/mapviewer.py
+++ b/plugins/wx/mapviewer.py
@@ -694,6 +694,8 @@ class TomographyPanel(GridPanel):
                                      style=wx.SP_VERTICAL|wx.SP_ARROW_KEYS|wx.SP_WRAP)
         self.refine_center.Bind(wx.EVT_CHECKBOX, self.refineCHOICE)
         
+        self.refine_center.SetValue(False)
+        
         #self.center_value.Bind(wx.EVT_SPINCTRLDOUBLE, self.set_center)
 
 
@@ -1665,7 +1667,7 @@ class MapInfoPanel(scrolled.ScrolledPanel):
                 self.wids['Ring Current'].SetLabel('%s mA' % val)
             elif ('mono.energy' in name or 'mono energy' in name) and cur_energy=='':
                 self.owner.current_energy = float(val)/1000.
-                self.file.mono_energy = float(val)/1000.
+                self.owner.current_file.mono_energy = float(val)/1000.
                 wvlgth = lambda_from_E(self.owner.current_energy)
                 self.wids['X-ray Energy'].SetLabel(u'%0.3f keV (%0.3f \u00c5)' % \
                                                    (self.owner.current_energy,wvlgth))

--- a/plugins/wx/mapviewer.py
+++ b/plugins/wx/mapviewer.py
@@ -479,8 +479,6 @@ class ROIPanel(GridPanel):
         
         GridPanel.__init__(self, parent, nrows=8, ncols=6, **kws)
 
-        #roiunits=['XRF: E (eV)','XRF: E (keV)',u'XRD: q (\u212B\u207B\u00B9)',u'XRD: 2\u03B8 (\u00B0)',u'XRD: d (\u212B)']
-
         self.roi_name =  wx.TextCtrl(self, -1, 'ROI_001',  size=(120, -1))        
         self.roi_chc  = [Choice(self, choices=[''],        size=(120, -1)),
                          Choice(self, choices=[''],        size=(120, -1))]
@@ -498,13 +496,37 @@ class ROIPanel(GridPanel):
         self.AddMany((SimpleText(self, 'Type:'),self.roi_chc[0]), dcol=1, style=LEFT,newrow=True)
         self.AddMany((SimpleText(self, 'Limits:'),self.roi_lims[0],self.roi_lims[1],self.roi_chc[1]), dcol=1, style=LEFT, newrow=True)
         self.AddMany((SimpleText(self, ''),self.roi_lims[2],self.roi_lims[3]), dcol=1, style=LEFT, newrow=True)
-        self.AddMany((SimpleText(self, ''),SimpleText(self, '')), dcol=1, style=LEFT, newrow=True)
+        self.Add(SimpleText(self, ''),newrow=True)
 
         self.Add(HLine(self, size=(500, 4)), dcol=8, style=LEFT,  newrow=True)
         
+        ###############################################################################
+
+        self.rm_roi_ch = [Choice(self, choices=[''],        size=(120, -1)),
+                          Choice(self, choices=[''],        size=(120, -1))]
+        fopts = dict(minval=-1, precision=3, size=(100, -1))
+        self.rm_roi_lims = SimpleText(self, '')
+
+        self.Add(SimpleText(self, ''),newrow=True)
+        self.Add(SimpleText(self, '--    Delete saved ROI    --'), dcol=6, style=LEFT, newrow=True)
+
+        self.Add(HLine(self, size=(500, 4)), dcol=8, style=LEFT,  newrow=True)
+        
+        self.AddMany((SimpleText(self, 'Detector:'),self.rm_roi_ch[0]), dcol=1, style=LEFT, newrow=True)
+        self.AddMany((SimpleText(self, 'ROI:'),self.rm_roi_ch[1]), dcol=1, style=LEFT,newrow=True)
+        self.Add(SimpleText(self, 'Limits:'), dcol=1, style=LEFT, newrow=True)
+        self.Add(self.rm_roi_lims, dcol=3, style=LEFT)
+        self.AddMany((SimpleText(self, ''),Button(self, 'Remove ROI', size=(100, -1), action=self.onRemoveROI)), dcol=1, style=LEFT, newrow=True)
+        self.Add(SimpleText(self, ''),newrow=True)
+
+        self.Add(HLine(self, size=(500, 4)), dcol=8, style=LEFT,  newrow=True)
+        
+               
         self.roi_chc[0].Bind(wx.EVT_CHOICE, self.roiUNITS)
         self.roi_lims[2].Disable()
         self.roi_lims[3].Disable()
+        
+        self.rm_roi_ch[1].Bind(wx.EVT_CHOICE, self.roiSELECT)
 
         self.pack()
         
@@ -518,15 +540,59 @@ class ROIPanel(GridPanel):
         
     def roiTYPE(self,event=None):
         roitype = []
+        delroi = []
         if self.file.flag_xrf:  
             roitype += ['XRF']
         if self.file.flag_xrd1d:  
             roitype += ['1DXRD']
+            delroi  = ['xrd1D']
         if self.file.flag_xrd2d:  
             roitype += ['2DXRD']
         if len(roitype) < 1: roitype = ['']
         self.roi_chc[0].SetChoices(roitype)
         self.roiUNITS()
+
+        self.rm_roi_ch[0].SetChoices(delroi)
+        if len(delroi) > 0:
+             self.setROI()
+        
+    def onRemoveROI(self,event=None):
+        
+        detname = self.rm_roi_ch[0].GetStringSelection()
+        roiname = self.rm_roi_ch[1].GetStringSelection()
+        
+        if detname == 'xrd1D':
+            self.file.del_xrd1Droi(roiname)
+            self.setROI()
+
+    def setROI(self):
+
+        detname = self.rm_roi_ch[0].GetStringSelection()
+        detgrp = self.file.xrmmap['roimap'][detname]
+        limits,names = [],detgrp.keys()
+        for name in names:
+            limits += [list(detgrp[name]['limits'][:])]
+            
+        self.rm_roi_ch[1].SetChoices([x for (y,x) in sorted(zip(limits,names))])
+        self.roiSELECT()
+        
+        
+    def roiSELECT(self,event=None):
+
+        detname = self.rm_roi_ch[0].GetStringSelection()
+        roiname = self.rm_roi_ch[1].GetStringSelection()
+
+        roi = self.file.xrmmap['roimap'][detname][roiname]
+        limits = roi['limits'][:]
+        units = roi['limits'].attrs['units']
+        
+        if units == '1/A':
+            roistr = '[%0.2f to %0.2f %s]' % (limits[0],limits[1],units)
+        else:
+            roistr = '[%0.1f to %0.1f %s]' % (limits[0],limits[1],units)
+
+        self.rm_roi_lims.SetLabel(roistr)
+
         
     def roiUNITS(self,event=None):
     
@@ -1599,6 +1665,7 @@ class MapInfoPanel(scrolled.ScrolledPanel):
                 self.wids['Ring Current'].SetLabel('%s mA' % val)
             elif ('mono.energy' in name or 'mono energy' in name) and cur_energy=='':
                 self.owner.current_energy = float(val)/1000.
+                self.file.mono_energy = float(val)/1000.
                 wvlgth = lambda_from_E(self.owner.current_energy)
                 self.wids['X-ray Energy'].SetLabel(u'%0.3f keV (%0.3f \u00c5)' % \
                                                    (self.owner.current_energy,wvlgth))

--- a/plugins/wx/mapviewer.py
+++ b/plugins/wx/mapviewer.py
@@ -2568,6 +2568,8 @@ class MapViewerFrame(wx.Frame):
                  'Load XRD calibration file',  self.openPONI)
         MenuItem(self, fmenu, '&Add 1DXRD for HDF5 file',
                  'Calculate 1DXRD for HDF5 file',  self.add1DXRD)
+        MenuItem(self, fmenu, 'Load R&OI File for 1DXRD',
+                 'Load ROI File for 1DXRD',  self.add1DXRDFile)
         fmenu.AppendSeparator()
 
         mid = wx.NewId()
@@ -2759,11 +2761,11 @@ class MapViewerFrame(wx.Frame):
         """
 
         myDlg = OpenPoniFile()
+        read = False
         if myDlg.ShowModal() == wx.ID_OK:
             read = True
             path = myDlg.PoniInfo[1].GetValue()
             flip = False if myDlg.PoniInfo[0].GetSelection() == 1 else True
-
         myDlg.Destroy()
 
         if read:
@@ -2771,6 +2773,23 @@ class MapViewerFrame(wx.Frame):
             for p in self.nbpanels:
                 if hasattr(p, 'update_xrmmap'):
                     p.update_xrmmap(self.current_file.xrmmap)
+
+    def add1DXRDFile(self, event=None):
+    
+        read = False    
+        wildcards = '1D-XRD ROI file (*.dat)|*.dat|All files (*.*)|*.*'
+        dlg = wx.FileDialog(self, message='Select 1D-XRD ROI file',
+                           defaultDir=os.getcwd(),
+                           wildcard=wildcards,
+                           style=wx.FD_OPEN)
+    
+        if dlg.ShowModal() == wx.ID_OK:
+            read = True
+            path = dlg.GetPath().replace('\\', '/')
+        dlg.Destroy()
+
+        if read and os.path.exists(path):
+            self.current_file.read_xrd1D_ROIFile(path,verbose=True)
                     
     def add1DXRD(self, event=None):
     

--- a/plugins/xafs/feffit.py
+++ b/plugins/xafs/feffit.py
@@ -186,6 +186,10 @@ class TransformGroup(Group):
         """cauchy wavelet transform -- meant to be used internally"""
         if self.kstep != self.__kstep or self.nfft != self.__nfft:
             self.make_karrays()
+        nkpts = len(chi)
+        nrpts = int(np.round(self.rmax/self.rstep))
+        if self.kwin is None:
+            self.make_cwt_arrays(nkpts, nrpts)
 
         omega = pi*np.arange(self.nfft)/(self.kstep*self.nfft)
 
@@ -194,7 +198,6 @@ class TransformGroup(Group):
         if kweight != 0:
             chi = chi * self.kwin[:len(chi)] * self.k_[:len(chi)]**kweight
 
-        nkpts = len(chi)
         if rmax is not None:
             self.rmax = rmax
 

--- a/plugins/xrd/xrd_pyFAI.py
+++ b/plugins/xrd/xrd_pyFAI.py
@@ -216,8 +216,11 @@ def save1D(filename, xaxis, I, error=None, xaxis_unit=None, calfile=None,
     '''
     copied and modified from pyFAI/io.py
     '''
-    if xaxis_unit is None:
+    if xaxis_unit is None or xaxis_unit == 'q':
         xaxis_unit = pyFAI.units.Q_A
+    elif xaxis_unit.startswith('2th'):
+        xaxis_unit = pyFAI.units.TTH_DEG
+            
     if calfile is None:
         ai = None
     else:

--- a/plugins/xrmmap/__init__.py
+++ b/plugins/xrmmap/__init__.py
@@ -3,7 +3,7 @@ from .xsp3_hdf5 import read_xsp3_hdf5
 from .xrf_netcdf import read_xrf_netcdf
 from .xrd_netcdf import read_xrd_netcdf
 from .xrd_hdf5 import read_xrd_hdf5
-from .asciifiles import (readASCII, readMasterFile, readROIFile, readXRD1DROIFile,
+from .asciifiles import (readASCII, readMasterFile, readROIFile,
                          readEnvironFile, read1DXRDFile, parseEnviron)
 from .xrm_mapfile import (read_xrfmap, h5str, ensure_subgroup,
                           GSEXRM_MapFile, GSEXRM_FileStatus,

--- a/plugins/xrmmap/asciifiles.py
+++ b/plugins/xrmmap/asciifiles.py
@@ -128,4 +128,4 @@ def readROIFile(hfile,xrd=False):
                         extra[attr] = tmpdat
     
     
-        return roidata, calib, extra, xrddata
+        return roidata, calib, extra

--- a/plugins/xrmmap/asciifiles.py
+++ b/plugins/xrmmap/asciifiles.py
@@ -75,58 +75,57 @@ def readScanConfig(folder):
     # return scan, general, timestamp
     return scan
 
-def readROIFile(hfile):
+def readROIFile(hfile,xrd=False):
+
     cp =  ConfigParser()
     cp.read(hfile)
     output = []
-    for a in cp.options('rois'):
-        if a.lower().startswith('roi'):
-            iroi = int(a[3:])
-            name, dat = cp.get('rois',a).split('|')
-            lims = [int(i) for i in dat.split()]
-            ndet = len(lims)/2
-            dat = []
-            for i in range(ndet):
-                dat.append((lims[i*2], lims[i*2+1]))
-            output.append((iroi, name.strip(), dat))
-    roidata = sorted(output)
-                          
-    calib = {}
 
-    caldat = cp.options('calibration')
-    for attr in ('offset', 'slope', 'quad'):
-        calib[attr] = [float(x) for x in cp.get('calibration', attr).split()]
-    extra = {}
-    ndet = len(calib['offset'])
-    file_sections = cp.sections()
-    for section in ('dxp', 'extra'):
-        if section not in file_sections:
-            continue
-        for attr in cp.options(section):
-            tmpdat = [x for x in cp.get(section, attr).split()]
-            if len(tmpdat) == 2*ndet:
-                tmpdat = ['%s %s' % (i, j) for i, j in zip(tmpdat[::2], tmpdat[1::2])]
-            try:
-                extra[attr] = [int(x) for x in tmpdat]
-            except ValueError:
+    if xrd:
+        for a in cp.options('xrd1d'):
+            if a.lower().startswith('roi'):
+                iroi = int(a[3:])
+                name,unit,dat = cp.get('xrd1d',a).split('|')
+                lims = [float(i) for i in dat.split()]
+                dat = [lims[0], lims[1]]
+                output.append((iroi, name.strip(), unit.strip(), dat))
+        return sorted(output)
+    
+    else:
+        for a in cp.options('rois'):
+            if a.lower().startswith('roi'):
+                iroi = int(a[3:])
+                name, dat = cp.get('rois',a).split('|')
+                lims = [int(i) for i in dat.split()]
+                ndet = len(lims)/2
+                dat = []
+                for i in range(ndet):
+                    dat.append((lims[i*2], lims[i*2+1]))
+                output.append((iroi, name.strip(), dat))
+        roidata = sorted(output)
+                          
+        calib = {}
+
+        caldat = cp.options('calibration')
+        for attr in ('offset', 'slope', 'quad'):
+            calib[attr] = [float(x) for x in cp.get('calibration', attr).split()]
+        extra = {}
+        ndet = len(calib['offset'])
+        file_sections = cp.sections()
+        for section in ('dxp', 'extra'):
+            if section not in file_sections:
+                continue
+            for attr in cp.options(section):
+                tmpdat = [x for x in cp.get(section, attr).split()]
+                if len(tmpdat) == 2*ndet:
+                    tmpdat = ['%s %s' % (i, j) for i, j in zip(tmpdat[::2], tmpdat[1::2])]
                 try:
-                    extra[attr] = [float(x) for x in tmpdat]
+                    extra[attr] = [int(x) for x in tmpdat]
                 except ValueError:
-                    extra[attr] = tmpdat
-    return roidata, calib, extra
-
-
-def readXRD1DROIFile(hfile):
-    cp =  ConfigParser()
-    cp.read(hfile)
-    output = []
-    for a in cp.options('rois'):
-        if a.lower().startswith('roi'):
-            iroi = int(a[3:])
-            name,unit,dat = cp.get('rois',a).split('|')
-            lims = [float(i) for i in dat.split()]
-            dat = [lims[0], lims[1]]
-            output.append((iroi, name.strip(), unit.strip(), dat))
-    roidata = sorted(output)
-                          
-    return roidata
+                    try:
+                        extra[attr] = [float(x) for x in tmpdat]
+                    except ValueError:
+                        extra[attr] = tmpdat
+    
+    
+        return roidata, calib, extra, xrddata

--- a/plugins/xrmmap/xrm_mapfile.py
+++ b/plugins/xrmmap/xrm_mapfile.py
@@ -1549,13 +1549,48 @@ class GSEXRM_MapFile(object):
                 print('1DXRD data already in file.')
                 return
 
+
+
+    def get_slice_y(self):
+        
+        for name, val in zip(list(self.xrmmap['config/environ/name']), 
+                             list(self.xrmmap['config/environ/value'])):
+            name = str(name).lower()
+            if name.startswith('sample'):
+                name = name.replace('samplestage.', '')
+                if name.lower() == 'fine y' or name.lower() == 'finey':
+                    return float(val)
+
+    def get_tomo_center(self):
+    
+        try:
+            return self.xrmmap['tomo/center'][...]
+        except:
+             self.update_tomo_center(None)
+             
+        return self.xrmmap['tomo/center'][...]
+
     def update_tomo_center(self,center):
+    
+        if not self.check_hostid():
+            raise GSEXRM_NotOwner(self.filename)
+        
+        if center is None:
+            try:
+                center = len(self.get_pos('fine x', mean=True))/2      
+            except:
+                center = len(self.get_pos('x', mean=True))/2   
+            
     
         tomogrp = ensure_subgroup('tomo',self.xrmmap)
         try:
-            tomogrp.create_dataset('center', data=center)
+            del tomogrp['center']
         except:
-            self.xrmmap['tomo/center'][...] = center
+            pass
+        tomogrp.create_dataset('center', data=center)
+            
+            
+        self.h5root.flush()
    
     def reset_flags(self):
         '''

--- a/plugins/xrmmap/xrm_mapfile.py
+++ b/plugins/xrmmap/xrm_mapfile.py
@@ -2629,20 +2629,24 @@ class GSEXRM_MapFile(object):
             print('Only compatible with newest hdf5 mapfile version.')
 
 
-    def read_xrd1D_ROIFile(self,filename,verbose=True):
+    def read_xrd1D_ROIFile(self,filename,verbose=False):
     
-        
         roidat = readROIFile(filename,xrd=True)
+        print('Reading 1D-XRD ROI file: %s' % filename)
         for iroi, label, xunit, xrange in roidat:
-            if verbose: print('Adding ROI: %s' % label)
+            if verbose:
+                t0 = time.time()
+                print('Adding ROI: %s' % label)
             self.add_xrd1Droi(xrange,label,unit=xunit)
-
-
+            if verbose:
+                print('    %0.2f s' % (time.time()-t0))
+        print(' Finished.\n')
 
     def add_xrd1Droi(self, xrange, roiname, unit='q'):
 
         if StrictVersion(self.version) >= StrictVersion('2.0.0'):     
-            if not self.flag_xrd1d:
+            if not self.xrmmap['flags'].attrs.get('xrd1D', False):
+                print('No 1D-XRD data in file')
                 return
             
             if self.mono_energy is None:

--- a/plugins/xrmmap/xrm_mapfile.py
+++ b/plugins/xrmmap/xrm_mapfile.py
@@ -2729,13 +2729,43 @@ class GSEXRM_MapFile(object):
             imax = (np.abs(qaxis-qrange[1])).argmin()+1
             xrd1d_counts = xrmdet['counts'][:,:,slice(imin,imax)].sum(axis=2)
             if abs(imax-imin) > 0:
-                xrd1d_cor = xrd1d_counts/abs(imax-imin)
+            
+                A = (xrmdet['counts'][:,:,imin]+xrmdet['counts'][:,:,imax])/2
+                B = abs(imax-imin)
+            
+                xrd1d_counts = xrd1d_counts - (A*B) ## subtracts approximate background
+                xrd1d_cor    = xrd1d_counts/B
             else:
                 xrd1d_cor = xrd1d_counts
 
             self.save_roi(roiname,detname,xrd1d_counts,xrd1d_cor,qrange,'q','1/A')
         else:
             print('Only compatible with newest hdf5 mapfile version.')
+
+    def del_all_xrd1Droi(self):
+
+        ''' delete all 1D-XRD ROI'''
+        
+        roigrp_xrd1d = ensure_subgroup('xrd1D',self.xrmmap['roimap'])
+        
+        for roiname in roigrp_xrd1d.keys():
+            self.del_xrd1Droi(roiname)
+
+    def del_xrd1Droi(self, roiname):
+
+        ''' delete a 1D-XRD ROI'''
+        
+        roigrp_xrd1d = ensure_subgroup('xrd1D',self.xrmmap['roimap'])
+        
+        if roiname not in roigrp_xrd1d.keys():
+            print("No ROI named '%s' found to delete" % roiname)
+            return
+
+        roiname = h5str(roiname)
+        if roiname in roigrp_xrd1d:
+            del roigrp_xrd1d[roiname]
+            self.h5root.flush()
+
 
     def save_roi(self,roiname,det,raw,cor,range,type,units):
     

--- a/plugins/xrmmap/xrm_mapfile.py
+++ b/plugins/xrmmap/xrm_mapfile.py
@@ -2625,6 +2625,16 @@ class GSEXRM_MapFile(object):
             print('Only compatible with newest hdf5 mapfile version.')
 
 
+    def read_xrd1D_ROIFile(self,filename,verbose=True):
+    
+        
+        roidat = readROIFile(filename,xrd=True)
+        for iroi, label, xunit, xrange in roidat:
+            if verbose: print('Adding ROI: %s' % label)
+            self.add_xrd1Droi(xrange,label,unit=xunit)
+
+
+
     def add_xrd1Droi(self, xrange, roiname, unit='q'):
 
         if StrictVersion(self.version) >= StrictVersion('2.0.0'):     

--- a/plugins/xrmmap/xrm_mapfile.py
+++ b/plugins/xrmmap/xrm_mapfile.py
@@ -2732,9 +2732,11 @@ class GSEXRM_MapFile(object):
             
                 A = (xrmdet['counts'][:,:,imin]+xrmdet['counts'][:,:,imax])/2
                 B = abs(imax-imin)
+                
+                ## cor = ( raw - AB ) / B = ( raw/B ) - A
             
-                xrd1d_counts = xrd1d_counts - (A*B) ## subtracts approximate background
-                xrd1d_cor    = xrd1d_counts/B
+                xrd1d_counts = xrd1d_counts / B ## divides by number of channels
+                xrd1d_cor    = xrd1d_counts - A ## subtracts 'average' background
             else:
                 xrd1d_cor = xrd1d_counts
 

--- a/plugins/xrmmap/xrm_mapfile.py
+++ b/plugins/xrmmap/xrm_mapfile.py
@@ -354,6 +354,7 @@ class GSEXRM_MapRow:
                 self.xrd2d[0:xrddat.shape[0]] = xrddat
             else:
                 self.xrd2d = xrddat[0:self.npts]
+            
             tg = time.time()
             if poni is not None and FLAGxrd1D:
                 attrs = {'steps':steps,'mask':mask,'flip':flip}
@@ -633,10 +634,10 @@ class GSEXRM_MapFile(object):
         self.masterfile       = None
         self.masterfile_mtime = -1
 
-        self.mono_energy     = None
-        self.flag_xrf   = FLAGxrf
-        self.flag_xrd1d = FLAGxrd1D
-        self.flag_xrd2d = FLAGxrd2D
+        self.mono_energy  = None
+        self.flag_xrf     = FLAGxrf
+        self.flag_xrd1d   = FLAGxrd1D
+        self.flag_xrd2d   = FLAGxrd2D
         
         self.calibration = poni
         self.maskfile    = mask
@@ -723,6 +724,7 @@ class GSEXRM_MapFile(object):
             if poni is not None: self.add_calibration(poni,flip)
         else:
             raise GSEXRM_Exception('GSEXMAP Error: could not locate map file or folder')
+            
 
     def __repr__(self):
         fname = ''
@@ -967,6 +969,12 @@ class GSEXRM_MapFile(object):
         '''read a row worth of raw data from the Map Folder
         returns arrays of data
         '''
+        
+        if self.calibration is None:
+            try:
+                self.calibration = self.xrmmap['xrd1D'].attrs['calfile']
+            except:
+                pass
 
         if self.dimension is None or irow > len(self.rowdata):
             self.read_master()
@@ -1948,6 +1956,17 @@ class GSEXRM_MapFile(object):
             yaddr = scanconf['pos2']
             self.pos_addr.append(yaddr)
             self.pos_desc.append(slow_pos[yaddr])
+            
+#         try:
+#             self.calibration = self.xrmmap['xrd1D'].attrs['calfile']
+#         except:
+#             pass
+#             
+#         flaggp = xrmmap['flags']
+#         flaggp.attrs['xrf']   = self.flag_xrf
+#         flaggp.attrs['xrd2D'] = self.flag_xrd2d
+#         flaggp.attrs['xrd1D'] = self.flag_xrd1d
+        
 
     def _det_name(self, det=None):
         "return  XRMMAP group for a detector"


### PR DESCRIPTION
Minor updates:
1. Remove area selection from Sinogram and Tomograph plots
2. Allow for loading a file for ROIS into hdf5 mapfile and for deletion of ROIs (restricted to 'xrd1D' at this time)
3. Display netcdf 2D-XRD files in diFFit2D 
4. Restructure read_rowdata to try to avoid 'lzf' compression errors
5. XRD1D ROI subtracts local background in 'corrected' and only accounts for number of changes in 'raw' 

