### PR TITLE
Found error in newest map building code

### DIFF
--- a/plugins/diFFit/XRD1Dviewer.py
+++ b/plugins/diFFit/XRD1Dviewer.py
@@ -3096,7 +3096,6 @@ class Calc1DPopup(wx.Dialog):
                                     size = (210,460))
         self.parent = parent
         self.data2D = xrd2Ddata
-        self.steps = 5001
 
         self.createPanel()
         
@@ -3190,10 +3189,6 @@ class Calc1DPopup(wx.Dialog):
 
     def onSPIN(self,event=None):
         self.wedges.SetValue(str(event.GetPosition()))
-
-    def getValues(self):
-
-        self.steps = int(self.xstep.GetValue())
 
 class DatabaseInfoGUI(wx.Dialog):
     '''

--- a/plugins/diFFit/XRD1Dviewer.py
+++ b/plugins/diFFit/XRD1Dviewer.py
@@ -824,7 +824,6 @@ class Fitting1DXRD(BasePanel):
                 qall,Iall = cif.qhkl,cif.Ihkl
                 Iall = Iall/max(Iall)*maxI
 
-                cifargs = {'label':cifname,'title':self.xrd1dgrp.label,'color':'green','label':cifname,'xlabel':self.xlabel,'ylabel':self.ylabel,'marker':'','markersize':0,'show_legend':True}
                 try:
                     cifdata = []
                     for i,I in enumerate(Iall):

--- a/plugins/diFFit/XRD2Dviewer.py
+++ b/plugins/diFFit/XRD2Dviewer.py
@@ -629,7 +629,7 @@ class diFFit2DFrame(wx.Frame):
                 if int(myDlg.xstep.GetValue()) < 1:
                     attrs = {'steps':5001}
                 else:
-                    attrs = {'steps':int(myDlg.steps)}
+                    attrs = {'steps':int(myDlg.xstep.GetValue())}
                 unit = '2th' if unts == 1 else 'q'
                 attrs.update({'unit':unit,'verbose':True})
             myDlg.Destroy()

--- a/plugins/wx/mapviewer.py
+++ b/plugins/wx/mapviewer.py
@@ -3234,19 +3234,6 @@ class OpenMapFolder(wx.Dialog):
             self.Fldr.SetValue('')
             self.FindWindowById(wx.ID_OK).Disable()
 
-#         if not os.path.exists(self.Fldr.GetValue()):
-#             self.Fldr.SetValue('')
-#             self.FindWindowById(wx.ID_OK).Disable()
-#             return
-#         
-#         add_data = False
-#         for ckbk in self.ChkBx:
-#             if ckbk.GetValue(): add_data = True
-#         if add_data:
-#             self.FindWindowById(wx.ID_OK).Enable()
-#         else:
-#             self.FindWindowById(wx.ID_OK).Disable()
-
     def onH5cmpr(self,event=None):
     
         if self.H5cmprInfo[0].GetSelection() == 0:

--- a/plugins/wx/mapviewer.py
+++ b/plugins/wx/mapviewer.py
@@ -3228,18 +3228,24 @@ class OpenMapFolder(wx.Dialog):
         else:
             for poniinfo in self.PoniInfo: poniinfo.Disable()
 
-        if not os.path.exists(self.Fldr.GetValue()):
-            self.Fldr.SetValue('')
-            self.FindWindowById(wx.ID_OK).Disable()
-            return
-        
-        add_data = False
-        for ckbk in self.ChkBx:
-            if ckbk.GetValue(): add_data = True
-        if add_data:
+        if os.path.exists(self.Fldr.GetValue()):
             self.FindWindowById(wx.ID_OK).Enable()
         else:
+            self.Fldr.SetValue('')
             self.FindWindowById(wx.ID_OK).Disable()
+
+#         if not os.path.exists(self.Fldr.GetValue()):
+#             self.Fldr.SetValue('')
+#             self.FindWindowById(wx.ID_OK).Disable()
+#             return
+#         
+#         add_data = False
+#         for ckbk in self.ChkBx:
+#             if ckbk.GetValue(): add_data = True
+#         if add_data:
+#             self.FindWindowById(wx.ID_OK).Enable()
+#         else:
+#             self.FindWindowById(wx.ID_OK).Disable()
 
     def onH5cmpr(self,event=None):
     

--- a/plugins/xrmmap/xrm_mapfile.py
+++ b/plugins/xrmmap/xrm_mapfile.py
@@ -220,11 +220,6 @@ class GSEXRM_MapRow:
                  mask=None, wdg=0, steps=STEPS, flip=True,
                  FLAGxrf=True, FLAGxrd2D=False, FLAGxrd1D=False):
 
-        ## need one type of data to build file; could be modified for just scalars?
-        ## mkak 2017.09.18
-        # if not FLAGxrf and not FLAGxrd2D and not FLAGxrd1D:
-        #     return
-
         self.read_ok = False
         self.nrows_expected = nrows_expected
 

--- a/plugins/xrmmap/xrm_mapfile.py
+++ b/plugins/xrmmap/xrm_mapfile.py
@@ -297,14 +297,14 @@ class GSEXRM_MapRow:
         if dtime is not None:  dtime.add('maprow: read ascii files')
         t0 = time.time()
 
-        atime = os.stat(os.path.join(folder, sisfile)).st_ctime
+        atime = -1
 
         xrf_dat,xrf_file = None,os.path.join(folder, xrffile)
         xrd_dat,xrd_file = None,os.path.join(folder, xrdfile)
 
         while atime < 0 and time.time()-t0 < 10:
             try:
-                if os.file.exists(xrf_file):
+                if os.path.exists(xrf_file):
                     atime = os.stat(xrf_file).st_ctime
                 if FLAGxrf:
                     xrf_dat = xrf_reader(xrf_file, npixels=self.nrows_expected, verbose=False)


### PR DESCRIPTION
Current version fails when building XRF only map:

plugins/xrmmap/xrm_mapfile.py: 
 ~line 300: atime is always larger than 0, so while statement never entered THEREFORE xrf_data is never defined. Testing now seems to function for with or without XRF data (e.g. only scalars should still function). Also, incorrect function call os.file.exists() changed to os.path.exists().

A few other minor updates also added, including the ability to build a map file through gui without any XRF or XRD data (only scalars).