### PR TITLE
Fix matplolib.use('WXAgg') warnings/errors

### DIFF
--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -9,8 +9,11 @@ import sys
 ## require that numpy be available right away!!
 import numpy
 
-import matplotlib
-matplotlib.use('WXAgg')
+try:
+    import matplotlib
+    matplotlib.use('WXAgg')
+except:
+    pass
 
 major, minor = sys.version_info[0], sys.version_info[1]
 if major < 2 or (major == 2 and minor < 7):

--- a/lib/fitting/__init__.py
+++ b/lib/fitting/__init__.py
@@ -14,7 +14,10 @@ from scipy.stats import f
 import matplotlib
 
 if HAS_WXPYTHON:
-    matplotlib.use("WXAgg")
+    try:
+        matplotlib.use("WXAgg")
+    except UserWarning:
+        pass
 
 import lmfit
 from lmfit import (Parameter, Parameters, Minimizer, conf_interval,

--- a/lib/fitting/__init__.py
+++ b/lib/fitting/__init__.py
@@ -12,12 +12,15 @@ import numpy as np
 from scipy.stats import f
 
 import matplotlib
+import warnings
 
 if HAS_WXPYTHON:
-    try:
-        matplotlib.use("WXAgg")
-    except UserWarning:
-        pass
+    with warnings.catch_warnings():
+        warnings.filterwarnings('error')
+        try:
+            matplotlib.use("WXAgg")
+        except:
+            pass
 
 import lmfit
 from lmfit import (Parameter, Parameters, Minimizer, conf_interval,


### PR DESCRIPTION
This small pull request is only to fix annoying warnings one gets if `import larch` is done within Ipython shell started as `ipython --gui=qt5` (in view of more integration with SILX).