### PR TITLE
database name

### DIFF
--- a/plugins/xray/xraydb.py
+++ b/plugins/xray/xraydb.py
@@ -198,7 +198,7 @@ class XrayDB(object):
     a complete listing.
     """
 
-    def __init__(self, dbname='xraydb.sqlite', read_only=True):
+    def __init__(self, dbname='xrayref.db', read_only=True): ##dbname='xraydb.sqlite'
         "connect to an existing database"
         if not os.path.exists(dbname):
             parent, child = os.path.split(__file__)


### PR DESCRIPTION
Default argument assignment for database named does not match name of x-ray reference database provided in build.