### PR TITLE
move gui-related requirements in a separate file

### DIFF
--- a/requirements-gui.txt
+++ b/requirements-gui.txt
@@ -1,0 +1,4 @@
+-r requirements.txt
+wxpython>=4.0.3
+wxutils>=0.2.2
+wxmplot>=0.9.32

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,3 @@ pyshortcuts>=1.3
 pyyaml
 psutil
 termcolor
-wxpython>=4.0.3
-wxutils>=0.2.2
-wxmplot>=0.9.32


### PR DESCRIPTION
I propose to keep only _core_ requirements in `requirements.txt`. This avoid forcing Wx (strong) dependency when building from source in those environments that do not need it (e.g. Jupyter notebooks, Qt-based GUI). 