### PR TITLE
Typo fixes and doc fixes to match code

### DIFF
--- a/doc/xafs/preedge.rst
+++ b/doc/xafs/preedge.rst
@@ -300,8 +300,8 @@ pre-edge peaks.
     :param group:     output group
     :param elo:       low energy of pre-edge peak region to not fit baseline [e0-20]
     :param ehi:       high energy of pre-edge peak region ot not fit baseline [e0-10]
-    :param emax:      max energy (eV) to use for baesline fit [e0-5]
-    :param emin:      min energy (eV) to use for baesline fit [e0-40]
+    :param emax:      max energy (eV) to use for baseline fit [e0-5]
+    :param emin:      min energy (eV) to use for baseline fit [e0-40]
     :param form:      form used for baseline (see note 2)  ['lorentzian']
     :param with_line: whether to include linear component in baseline [``True``]
 

--- a/doc/xafs/utilities.rst
+++ b/doc/xafs/utilities.rst
@@ -353,38 +353,38 @@ examples in the following sections in this chapter make use of these macros.
 :func:`plot_prepeaks_baseline`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: plot_prepeaks_baseline(dataset, subtract_baseline=False, show_fitrange=True, show_peakrange=True, win=1, **kws):
+.. function:: plot_prepeaks_baseline(dgroup, subtract_baseline=False, show_fitrange=True, show_peakrange=True, win=1, **kws):
 
     Plot pre-edge peaks and baseline fit, as from :func:`pre_edge_baseline`
     or XAS Viewer GUI
 
 
-    :param dataset:      data group, after running :func:`pre_edge_baseline`
+    :param dgroup:      data group, after running :func:`pre_edge_baseline`
     :param subtract_baseline:  bool whether to subtract baseline for plot
     :param show_fitrange:  bool whether to show fit range as vertical bars
     :param show_peakrange:  bool whether to show pre-edge peak range with markers
     :param win:          integer plot window to use [1]
     :param kws:          additional keyword arguments are passed to plot()
 
-    The `dataset` group must have a `prepeaks` subgroup.
+    The `dgroup` group must have a `prepeaks` subgroup.
 
 
 :func:`plot_prepeaks_fit`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. function:: plot_prepeaks_fit(dataset, show_init=False, subtract_baseline=False, show_residual=False, win=1, **kws):
+.. function:: plot_prepeaks_fit(dgroup, show_init=False, subtract_baseline=False, show_residual=False, win=1, **kws):
 
     Plot pre-edge peaks and fit, as XAS Viewer GUI
 
 
-    :param dataset:      data group, after running pre-edge peak fit.
+    :param dgroup:      data group, after running pre-edge peak fit.
     :param show_init:    bool whether to show initial model, before fitting
     :param subtract_baseline:  bool whether to subtract baseline for plot
     :param show_residual:  bool whether to show residual as a stacked plot.
     :param win:          integer plot window to use [1]
     :param kws:          additional keyword arguments are passed to plot()
 
-    The `dataset` group must have a `peakfit_history` subgroup. Currently,
+    The `dgroup` group must have a `peakfit_history` subgroup. Currently,
     this is automatically generated only using the XAS Viewer GUI or
     scripts written (and possibly altered) by it.
 

--- a/larch/xafs/xafsplots.py
+++ b/larch/xafs/xafsplots.py
@@ -758,7 +758,7 @@ def plot_prepeaks_baseline(dgroup, subtract_baseline=False, show_fitrange=True,
     px0, px1, py0, py1 = extend_plotrange(dgroup.xdat, dgroup.ydat,
                                           xmin=ppeak.emin, xmax=ppeak.emax)
 
-    title = "pre_edge baesline\n %s" % dgroup.filename
+    title = "pre_edge baseline\n %s" % dgroup.filename
 
     popts = dict(xmin=px0, xmax=px1, ymin=py0, ymax=py1, title=title,
                  xlabel='Energy (eV)', ylabel='mu', delay_draw=True,


### PR DESCRIPTION
Biggest issue this fixes is `plot_prepeaks_baseline` and `plot_prepeaks_fit` not using `dataset` but `dgroup` as a variable name when passing named variables.

eg. `plot_prepeaks_baseline(dataset=myGroup)` doesn't work but `plot_prepeaks_baseline(dgroup=myGroup)` does