### PR TITLE
Ignore broken wxpython installs raising AttributeError

### DIFF
--- a/larch/builtins.py
+++ b/larch/builtins.py
@@ -39,7 +39,7 @@ except ImportError:
 try:
     import wx
     HAS_WXPYTHON = True
-except ImportError:
+except (ImportError, AttributeError):
     HAS_WXPYTHON = False
 
 from . import wxlib

--- a/larch/wxlib/__init__.py
+++ b/larch/wxlib/__init__.py
@@ -19,7 +19,7 @@ HAS_WXPYTHON = False
 try:
     import wx
     HAS_WXPYTHON = True
-except ImportError:
+except (ImportError, AttributeError):
     HAS_WXPYTHON = False
 
 _larch_name = '_sys.wx'


### PR DESCRIPTION
Sometimes `wxpython` is badly installed and it raises an AttributeError at `import wx`. I do not know why it happens and it is not easy to reproduce. For example, it fails in this [environment on mybinder.org](https://mybinder.org/v2/gh/maurov/xraylarch/66225f9?filepath=examples%2FJupyter%2FXAFS_Processing.ipynb), while the very same environment installed locally on an Ubuntu machine works. 

The simplest solution at the moment is to consider `HAS_WXPYTHON = False` at the AttributeError, as this pull request does.