### PR TITLE
Swap time.clock to time.monotonic

### DIFF
--- a/larch/wxlib/inputhook.py
+++ b/larch/wxlib/inputhook.py
@@ -77,7 +77,7 @@ def stdin_ready():
 
 if sys.platform == 'win32':
     from msvcrt import kbhit as stdin_ready
-    clock = time.clock
+    clock = time.monotonic
     def ignore_CtrlC():
         pass
 elif sys.platform == 'darwin':

--- a/larch/xafs/diffkk.py
+++ b/larch/xafs/diffkk.py
@@ -263,7 +263,7 @@ class diffKKGroup(Group):
         if self.mback_kws is not None:
             mb_kws.update(self.mback_kws)
 
-        start = time.clock()
+        start = time.monotonic()
 
         mback(self.energy, self.mu, group=self, **mb_kws)
 
@@ -284,7 +284,7 @@ class diffKKGroup(Group):
         ## clean up group
         #for att in ('normalization_function', 'weight', 'grid'):
         #    if hasattr(self, att): delattr(self, att)
-        finish = time.clock()
+        finish = time.monotonic()
         self.time_elapsed = float(finish-start)
 
 def diffkk(energy=None, mu=None, z=None, edge='K', mback_kws=None, **kws):

--- a/larch/xsw/SimpleParratt.py
+++ b/larch/xsw/SimpleParratt.py
@@ -218,6 +218,6 @@ if __name__=='__main__':
     #test
     # reload(readf1f2a)
     import time
-    a=time.clock()
+    a=time.monotonic()
     reflectivity()
-    print(time.clock()-a, 'seconds')
+    print(time.monotonic()-a, 'seconds')

--- a/larch/xsw/YongsCode/SimpleParratt.py
+++ b/larch/xsw/YongsCode/SimpleParratt.py
@@ -214,9 +214,9 @@ if __name__=='__main__':
     #test
     reload(readf1f2a)
     import time
-    a=time.clock()
+    a=time.monotonic()
     reflectivity()  
-    print(time.clock()-a, 'seconds')
+    print(time.monotonic()-a, 'seconds')
 
 
 


### PR DESCRIPTION
time.clock is deprecated and has been removed in Python3.8.

This changes all references to time.monotonic, which is equivalent

Related issue: #274 