### PR TITLE
add automatic version increase with git hash

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -166,6 +166,8 @@ if INSTALL:
 
 # now we have all the data files, so we can run setup
 setup(name = 'xraylarch',
+      use_scm_version=True,
+      setup_requires=['setuptools_scm'],
       version = __version__,
       author = 'Matthew Newville and the X-rayLarch Development Team',
       author_email = 'newville@cars.uchicago.edu',


### PR DESCRIPTION
@newville, first of all, thanks for releasing `0.9.52`, that's great!

In order to have life easier identifying which is the Larch version when installing from source, I propose using `setuptools_scm` in the setup. It adds the git hash to the version (and may be further configured!).

I find it useful, but if for you it is not, feel free to discard this pull request.