### PR TITLE
Fix specfile importer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ Thumbs.db
 *.ipynb_checkpoints/
 .vscode/
 .empty/
+.eggs/

--- a/larch/io/specfile_reader.py
+++ b/larch/io/specfile_reader.py
@@ -259,8 +259,16 @@ class DataSourceSpecH5(object):
         self._sourcefile.close()
         self._sourcefile = None
 
-    def get_scangroup(self):
-        """get current scan group"""
+    def get_scangroup(self, scan=None):
+        """get current scan group
+
+        Parameters
+        ----------
+        scan  : str, int, or None
+             scan address
+        """
+        if scan is not None:
+            self.set_scan(scan)        
         if self._scangroup is None:
             raise AttributeError(
                 "Group/Scan not selected -> use 'self.set_scan()' first"
@@ -580,14 +588,19 @@ class DataSourceSpecH5(object):
             self._logger.error(f"'{mot}' not found in available motors: {mots}")
             return None
 
-    def get_scan(self):
+    def get_scan(self, scan=None):
         """Get Larch group for the current scan
+
+        Parameters
+        ----------
+        scan  : str, int, or None
+             scan address 
 
         Returns
         -------
         larch Group with scan data
         """
-        scan_group = self.get_scangroup()
+        scan_group = self.get_scangroup(scan)
         scan_index = self._scan_n
         scan_name = self._scan_str
         all_labels = self.get_counters()
@@ -757,6 +770,4 @@ def open_specfile(filename):
 def read_specfile(filename, scan=None):
     """simple mapping of a Spec/BLISS file to a Larch group"""
     df = DataSourceSpecH5(filename)
-    if scan is not None:
-        df.set_scan(scan)
-    return df.get_scan()
+    return df.get_scan(scan)

--- a/larch/io/specfile_reader.py
+++ b/larch/io/specfile_reader.py
@@ -463,7 +463,7 @@ class DataSourceSpecH5(object):
 
         Known types of scans
         --------------------
-        'ascan'/'dscan'
+        Generic: <scan_type> <scan_axis> <start> <end> <npoints> <counting_time>
         'Escan' (ESRF-BM30/BM16)
         'Emiscan' (ESRF-BM30/BM16)
         'fscan' (ESRF-ID26)
@@ -493,22 +493,9 @@ class DataSourceSpecH5(object):
         if isinstance(_title, np.ndarray):
             _title = np.char.decode(_title)[0]
         _title_splitted = [s for s in _title.split(" ") if not s == ""]
-        _iax = 0
-        _scntype = _title_splitted[_iax]
+        _scntype = _title_splitted[0]
+        iscn.update(dict(scan_type=_scntype))
         try:
-            iscn.update(
-                dict(
-                    scan_type=_scntype,
-                    scan_start=_title_splitted[1],
-                    scan_end=_title_splitted[2],
-                    scan_pts=_title_splitted[3],
-                    scan_ct=_title_splitted[4],
-                )
-            )
-        except IndexError:
-            pass
-
-        if _scntype in ("ascan", "dscan"):
             iscn.update(
                 dict(
                     scan_axis=_title_splitted[1],
@@ -518,6 +505,19 @@ class DataSourceSpecH5(object):
                     scan_ct=_title_splitted[5],
                 )
             )
+        except IndexError:
+            try:
+                iscn.update(
+                    dict(
+                        scan_start=_title_splitted[1],
+                        scan_end=_title_splitted[2],
+                        scan_pts=_title_splitted[3],
+                        scan_ct=_title_splitted[4],
+                    )
+                )
+            except IndexError:
+                pass
+
         if _scntype == "Escan":
             iscn.update(dict(scan_axis="Energy"))
         if _scntype == "Emiscan":

--- a/larch/xafs/xafsutils.py
+++ b/larch/xafs/xafsutils.py
@@ -37,13 +37,16 @@ def guess_energy_units(e):
     ediff = np.diff(ework)
     emax = max(ework)
 
-    units = 'eV'
-    if emax > 200000:
-        units = 'steps'
-    if emax < 120.0 and (abs(ediff).min() < 0.005):
-        units = 'keV'
-        if emax < 90.0 and (ediff.mean() < 0.0):
-            units = 'deg'
+    try:
+        units = 'eV'
+        if emax > 200000:
+            units = 'steps'
+        if emax < 120.0 and (abs(ediff).min() < 0.005):
+            units = 'keV'
+            if emax < 90.0 and (ediff.mean() < 0.0):
+                units = 'deg'
+    except ValueError:
+        units = 'unknown'
     return units
 
 def set_xafsGroup(group, _larch=None):


### PR DESCRIPTION
@newville I just found that I broke `specfile_importer` when removing `scan=None` parameter in some redundant places. Unfortunately, this makes the current Spec/BLISS importer boken in the current release (= useless for our users). Would it be possible to merge this and redo the `0.9.52` release?

I am very sorry for the inconvenience... I really should implement automatic testing for this!