### PR TITLE
Avoid WX non-US locales issue on Windows.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -2,7 +2,7 @@
 environment:
   matrix:
     - PYTHON_VERSION: "3.8"
-      MINICONDA: "C:\\Miniconda36-x64"
+      MINICONDA: "C:\\Miniconda38-x64"
 
 install:
     - "%MINICONDA%\\Scripts\\activate.bat"

--- a/larch/epics/xrfcontrol.py
+++ b/larch/epics/xrfcontrol.py
@@ -699,6 +699,7 @@ class EpicsXRFApp(wx.App, wx.lib.mixins.inspection.InspectionMixin):
         wx.App.__init__(self)
 
     def OnInit(self):
+        self.ResetLocale()
         self.Init()
         frame = EpicsXRFDisplayFrame(**self.kws) #
         frame.Show()

--- a/larch/wxlib/cif_browser.py
+++ b/larch/wxlib/cif_browser.py
@@ -672,6 +672,7 @@ class CIFViewer(wx.App, wx.lib.mixins.inspection.InspectionMixin):
         self.SetTopWindow(frame)
 
     def OnInit(self):
+        self.ResetLocale()
         self.createApp()
         return True
 

--- a/larch/wxlib/feff_browser.py
+++ b/larch/wxlib/feff_browser.py
@@ -555,6 +555,7 @@ class Viewer(wx.App, wx.lib.mixins.inspection.InspectionMixin):
         self.SetTopWindow(frame)
 
     def OnInit(self):
+        self.ResetLocale()
         self.createApp()
         return True
 

--- a/larch/wxlib/larchfilling.py
+++ b/larch/wxlib/larchfilling.py
@@ -532,6 +532,7 @@ class FillingFrame(wx.Frame):
 class App(wx.App):
     """PyFilling standalone application."""
     def OnInit(self):
+        self.ResetLocale()
         wx.InitAllImageHandlers()
         self.fillingFrame = FillingFrame()
         self.fillingFrame.Show(True)

--- a/larch/wxlib/larchframe.py
+++ b/larch/wxlib/larchframe.py
@@ -601,6 +601,7 @@ class LarchApp(wx.App, wx.lib.mixins.inspection.InspectionMixin):
         wx.App.__init__(self, **kws)
 
     def OnInit(self):
+        self.ResetLocale()
         frame = LarchFrame(exit_on_close=True, with_inspection=False)
         frame.Show()
         self.SetTopWindow(frame)

--- a/larch/wxlib/parameter.py
+++ b/larch/wxlib/parameter.py
@@ -486,6 +486,7 @@ class TestApp(wx.App, wx.lib.mixins.inspection.InspectionMixin):
         wx.App.__init__(self)
 
     def OnInit(self):
+        self.ResetLocale()
         self.Init()
         frame = TestFrame()
         frame.Show()

--- a/larch/wxlib/periodictable.py
+++ b/larch/wxlib/periodictable.py
@@ -277,6 +277,7 @@ class PTableApp(wx.App, wx.lib.mixins.inspection.InspectionMixin):
         wx.App.__init__(self)
 
     def OnInit(self):
+        self.ResetLocale()
         self.Init()
         frame = PTableFrame() #
         frame.Show()

--- a/larch/wxlib/xrfdisplay.py
+++ b/larch/wxlib/xrfdisplay.py
@@ -1390,6 +1390,7 @@ class XRFApp(wx.App, wx.lib.mixins.inspection.InspectionMixin):
         wx.App.__init__(self)
 
     def OnInit(self):
+        self.ResetLocale()
         self.Init()
         frame = XRFDisplayFrame(filename=self.filename)
         frame.Show()

--- a/larch/wxmap/gse_dtcorrect.py
+++ b/larch/wxmap/gse_dtcorrect.py
@@ -209,6 +209,7 @@ class DTViewer(wx.App, wx.lib.mixins.inspection.InspectionMixin):
         self.SetTopWindow(frame)
 
     def OnInit(self):
+        self.ResetLocale()
         self.createApp()
         return True
 

--- a/larch/wxmap/mapviewer.py
+++ b/larch/wxmap/mapviewer.py
@@ -2676,6 +2676,7 @@ class MapViewer(wx.App, wx.lib.mixins.inspection.InspectionMixin):
         self.SetTopWindow(frame)
 
     def OnInit(self):
+        self.ResetLocale()
         self.Init()
         self.createApp()
         if self.with_inspect:

--- a/larch/wxxas/xasgui.py
+++ b/larch/wxxas/xasgui.py
@@ -962,6 +962,7 @@ class XASViewer(wx.App, wx.lib.mixins.inspection.InspectionMixin):
         self.SetTopWindow(frame)
 
     def OnInit(self):
+        self.ResetLocale()
         self.createApp()
         return True
 

--- a/larch/wxxrd/XRD1Dviewer.py
+++ b/larch/wxxrd/XRD1Dviewer.py
@@ -3954,6 +3954,7 @@ class XRD1DViewer(wx.App):
         self.SetTopWindow(frame)
 
     def OnInit(self):
+        self.ResetLocale()
         self.createApp()
         return True
 

--- a/larch/wxxrd/XRD2Dviewer.py
+++ b/larch/wxxrd/XRD2Dviewer.py
@@ -1398,6 +1398,7 @@ class XRD2DViewer(wx.App):
         self.SetTopWindow(frame)
 
     def OnInit(self):
+        self.ResetLocale()
         self.createApp()
         return True
 

--- a/larch/xsw/YongsCode/SimpleParratt_Panel.py
+++ b/larch/xsw/YongsCode/SimpleParratt_Panel.py
@@ -395,6 +395,7 @@ class Plot(wx.Dialog):
 
 class MyApp(wx.App):
     def OnInit(self):
+        self.ResetLocale()
         dlg = Plot(None, -1, 'panel.py')
         dlg.Show(True)
         dlg.Centre()

--- a/larch/xsw/YongsCode/fluo_panel.py
+++ b/larch/xsw/YongsCode/fluo_panel.py
@@ -311,6 +311,7 @@ class Plot(wx.Dialog):
 
 class MyApp(wx.App):
        def OnInit(self):
+                 self.ResetLocale()
                  dlg = Plot(None, -1, 'fluo_panel.py')
                  dlg.Show(True)
                  dlg.Centre()


### PR DESCRIPTION
Add `ResetLocale()` to `wx.App` `OnInit()` to avoid error on MS Windows with non-US locales.
The error appears at least on Py >= 3.8 and Wx 4.1.1.

See for example wxWidgets/Phoenix#1751