### PR TITLE
Fix a typo in github workflows

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -22,7 +22,7 @@ jobs:
         printenv
         conda config --set always_yes yes --set changeps1 no
         conda config --add channels conda-forge
-        conda install python=${{ matrix.python-vesion }} numpy=>1.20 scipy=>1.5 matplotlib=>3.0 h5py pip setuptools pyparsing pytest pytest-cov coverage scikit-learn cython pillow pandas sqlalchemy psutil pyyaml psycopg2-binary numdifftools emcee pymatgen tomopy wxpython
+        conda install python=${{ matrix.python-version }} numpy=>1.20 scipy=>1.5 matplotlib=>3.0 h5py pip setuptools pyparsing pytest pytest-cov coverage scikit-learn cython pillow pandas sqlalchemy psutil pyyaml psycopg2-binary numdifftools emcee pymatgen tomopy wxpython
         conda info -a
         conda list
     - name: Install xraylarch

--- a/.github/workflows/test-with-conda.yml
+++ b/.github/workflows/test-with-conda.yml
@@ -24,7 +24,7 @@ jobs:
       run: |
         conda config --set always_yes yes --set changeps1 no
         conda config --add channels conda-forge
-        conda install python=${{ matrix.python-vesion }} numpy=>1.20 scipy=>1.5 matplotlib=>3.0 h5py pip setuptools pyparsing pytest pytest-cov coverage scikit-learn cython pillow pandas sqlalchemy psutil pyyaml psycopg2-binary numdifftools emcee pymatgen tomopy wxpython
+        conda install python=${{ matrix.python-version }} numpy=>1.20 scipy=>1.5 matplotlib=>3.0 h5py pip setuptools pyparsing pytest pytest-cov coverage scikit-learn cython pillow pandas sqlalchemy psutil pyyaml psycopg2-binary numdifftools emcee pymatgen tomopy wxpython
         conda info -a
         conda list
     - name: Install xraylarch

--- a/README.rst
+++ b/README.rst
@@ -3,13 +3,15 @@ Larch:  Data Analysis Tools for X-ray Spectroscopy and More
 
 .. image::  https://github.com/xraypy/xraylarch/actions/workflows/test-with-conda.yml/badge.svg
    :target: https://github.com/xraypy/xraylarch/actions/workflows/test-with-conda.yml
+
+.. image::  https://github.com/xraypy/xraylarch/actions/workflows/test-windows.yml/badge.svg
+   :target: https://github.com/xraypy/xraylarch/actions/workflows/test-windows.yml
 	    
 .. _scipy: https://scipy.org/
 .. _numpy: https://numpy.scipy.org/
 .. _matplotlib: https://matplotlib.org/
 .. _h5py: https://code.google.com/p/h5py/
 .. _Demeter: https://bruceravel.github.io/demeter/
-.. _Dioptas: https://github.com/Dioptas/Dioptas
 
 * Documentation: http://xraypy.github.io/xraylarch
 * Code: http://github.com/xraypy/xraylarch
@@ -56,8 +58,7 @@ Larch Applications
 
 These applications installed with Larch, in addition to a basic Python
 library. Here, GUI = Graphical User Interface, CLI = Command Line
-Interface, and `beta` indicates a work in progress.  The `Dioptas`_ program
-is written and maintained by Clemens Prescher, and included with Larch.
+Interface, and `beta` indicates a work in progress.
 
 
 +-------------------+------------+---------------------------------------------------------+
@@ -68,13 +69,12 @@ is written and maintained by Clemens Prescher, and included with Larch.
 | Larch GUI         | GUI        | enhanced command-line interface with data browser       |
 +-------------------+------------+---------------------------------------------------------+
 | XAS Viewer        | GUI        | XAFS Processing and Analysis: XANES pre-edge peak       |
-|                   |            | fitting, linear analysis, PCA/LASSO, EXAFS extraction   |
+|                   |            | fitting, linear analysis, PCA/LASSO, EXAFS processing,  |
+|                   |            | Running Feff, fitting EXAFS data to Feff paths.         |
 +-------------------+------------+---------------------------------------------------------+
 | GSE Map Viewer    | GUI        | XRF Map Viewer for GSECARS X-ray microprobe data.       |
 +-------------------+------------+---------------------------------------------------------+
 | XRF Display       | GUI        | Display and analyze XRF Spectra.                        |
-+-------------------+------------+---------------------------------------------------------+
-| Dioptas           | GUI        | Display XRD images, calibrate to XRD patterns.          |
 +-------------------+------------+---------------------------------------------------------+
 | feff6l            | CLI        | Feff 6 EXAFS calculations                               |
 +-------------------+------------+---------------------------------------------------------+


### PR DESCRIPTION
There is a typo in variable name, at the moment, it runs

`conda install python= numpy=>1.20 scipy...`

As a consequence, python 3.8 is also installed in 3.7 build so the tests are not really done in 3.7.