### PR TITLE
Set workflow for testing python 3.7, 3.8, 3.9 in Conda / Ubuntu

### DIFF
--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -10,19 +10,32 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.7', '3.8']
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python from Miniconda
       uses: conda-incubator/setup-miniconda@v2
       with:
-          auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
+        miniconda-version: latest
+        python-version: ${{ matrix.python-version }}
     - name: Install conda dependencies
       run: |
-        printenv
-        conda config --set always_yes yes --set changeps1 no
+        # printenv
+        conda update -n base -c defaults conda
+        conda config --set always_yes true --set changeps1 true
         conda config --add channels conda-forge
-        conda install python=${{ matrix.python-version }} numpy=>1.20 scipy=>1.5 matplotlib=>3.0 h5py pip setuptools pyparsing pytest pytest-cov coverage scikit-learn cython pillow pandas sqlalchemy psutil pyyaml psycopg2-binary numdifftools emcee pymatgen tomopy wxpython
+        conda install python=${{ matrix.python-version }}
+        conda info -a
+        conda install "numpy=>1.20" "scipy=>1.5" "matplotlib=>3.0" scikit-learn pandas
+        conda install pyparsing pytest pytest-cov coverage
+        conda install h5py pillow  sqlalchemy psutil pyyaml
+        conda install psycopg2-binary numdifftools emcee
+        #conda install tomopy
+        conda install wxpython
+        conda install pymatgen
+        conda install cython
         conda info -a
         conda list
     - name: Install xraylarch and other dependencies with pip

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -9,10 +9,7 @@ jobs:
       max-parallel: 5
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8']
-    defaults:
-      run:
-        shell: bash -l {0}
+        python-version: ['3.7', '3.8', '3.9']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python from Miniconda

--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -10,6 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.7', '3.8', '3.9']
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python from Miniconda

--- a/larch/version.py
+++ b/larch/version.py
@@ -10,7 +10,12 @@ import matplotlib
 import lmfit
 from collections import OrderedDict, namedtuple
 from packaging.version import parse as ver_parse
-from importlib.metadata import version, PackageNotFoundError
+
+try:
+    from importlib.metadata import version, PackageNotFoundError
+except ImportError: # for Python<3.8
+    from importlib_metadata import version, PackageNotFoundError
+
 try:
     __version__ = version("xraylarch")
 except PackageNotFoundError:


### PR DESCRIPTION
Changed `test-ubuntu.yml` for testing with Miniconda on Ubuntu.

Package installs are separated in different calls, otherwise installer just "hangs" (takes very long to resolve dependencies).
Bash shell is set as default. 
Version constrains are quoted to avoid shell redirections.
