### PR TITLE
allows importing larch without the non-required wxpython tools

### DIFF
--- a/larch/__init__.py
+++ b/larch/__init__.py
@@ -52,12 +52,18 @@ from .site_config import show_site_config
 from . import builtins
 from .inputText import InputText
 from .interpreter import Interpreter
-from . import larchlib, utils, version, site_config, apps
+from . import larchlib, utils, version, site_config
 
 from . import fitting, math, io
 from .fitting import Parameter, isParameter, param_value
 
-from . import shell
+try:
+    from . import apps
+    from . import shell
+except ImportError as e:
+    logger.warning(
+        "Larchs apps and shell are not supported due to missing dependencies: {}".format(e)
+    )
 
 logger.level = logging.INFO
 


### PR DESCRIPTION
Without `wxmplot` and `wxutils` the larch apps and shell do not work but larch is still useful as a library (for the computational things). As these dependencies are [not required](https://xraypy.github.io/xraylarch/installation.html#install-with-python) this PR proposes to capture import errors for `app` and `shell` when importing larch.