### PR TITLE
Fix github workflow for Ubuntu, python 3.7

### DIFF
--- a/.github/workflows/test-ubuntu.yml
+++ b/.github/workflows/test-ubuntu.yml
@@ -15,6 +15,11 @@ jobs:
         shell: bash -l {0}
     steps:
     - uses: actions/checkout@v2
+    - name: Install X system libraries for 3.7
+      if: ${{ matrix.python-version == '3.7'}}
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libxxf86vm1 libgtk2.0 libgtk2.0-dev
     - name: Set up Python from Miniconda
       uses: conda-incubator/setup-miniconda@v2
       with:


### PR DESCRIPTION
Tests for Ubuntu are failing because some graphical libraries are missing in github Ubuntu image and must be
manually installed before testing. This only happens for python 3.7. 

This PR changes `.github/workflows/test-ubuntu.yml` and  installs the missing libraries (`libxxf86vm1`, `libgtk2.0` and `libgtk2.0-dev`) when testing in python 3.7.

I don't know the reason why it sudenly stopped working. Was there a change in github images?