### PR TITLE
fix get array labels for a single line header

### DIFF
--- a/larch/io/xafs_beamlines.py
+++ b/larch/io/xafs_beamlines.py
@@ -89,8 +89,6 @@ class GenericBeamlineData:
         return len(self.headerlines) > 1
 
     def get_array_labels(self, ncolumns=None):
-        if len(self.headerlines) < 2:
-            return None
 
         lastline = self.headerlines[-1].strip()
         for cchars in ('#L', '#C', '#', 'C'):
@@ -98,7 +96,10 @@ class GenericBeamlineData:
                 lastline = lastline[len(cchars):]
         for badchar in ',#@%&"\'':
             lastline = lastline.replace(badchar, ' ')
-        return self._set_labels(lastline.split(), ncolumns=ncolumns)
+        if len(self.headerlines) < 2:
+            return self._set_labels(lastline.split(" "), ncolumns=ncolumns)
+        else:
+            return self._set_labels(lastline.split(), ncolumns=ncolumns)
 
     def _set_labels(self, labels, ncolumns=None):
         """

--- a/larch/io/xafs_beamlines.py
+++ b/larch/io/xafs_beamlines.py
@@ -97,7 +97,10 @@ class GenericBeamlineData:
         for badchar in ',#@%&"\'':
             lastline = lastline.replace(badchar, ' ')
         if len(self.headerlines) < 2:
-            return self._set_labels(lastline.split(" "), ncolumns=ncolumns)
+            try:
+                return self._set_labels(lastline.split(" "), ncolumns=ncolumns)
+            except Exception:
+                return None
         else:
             return self._set_labels(lastline.split(), ncolumns=ncolumns)
 


### PR DESCRIPTION
@newville this is a quick fix for getting correct parsing of array labels for those data files containing a single line header as:

`#eBraggEnergy I0_EH1 I1_EH1 mu I1_EH2 IR_EH2 mu_ref`

I got this on a file coming from BM08 at ESRF, but it is a usual case. This avoids having generic `col1 col2 ... colN` array labels.