### PR TITLE
Fix for Python 3.10

### DIFF
--- a/larch/xafs/feffit.py
+++ b/larch/xafs/feffit.py
@@ -2,7 +2,10 @@
 """
    feffit sums Feff paths to match xafs data
 """
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 from copy import copy, deepcopy
 from functools import partial
 import numpy as np


### PR DESCRIPTION
Importing of `Iterable` from `collections` is deprecated since Python 3.3 and finally removed in Python 3.10.