### PR TITLE
handle broken HDF5 links for scans

### DIFF
--- a/larch/io/specfile_reader.py
+++ b/larch/io/specfile_reader.py
@@ -418,7 +418,10 @@ class DataSourceSpecH5(object):
         """
         allscans = []
         for sn in self._sourcefile["/"].keys():
-            sg = self._sourcefile[sn]
+            try:
+                sg = self._sourcefile[sn]
+            except KeyError:
+                continue  # broken HDF5 link
             try:
                 allscans.append(
                     [


### PR DESCRIPTION
Closes #354

Skip scans that cannot be read due to broken HDF5 links.