### PR TITLE
add counter in displayname

### DIFF
--- a/larch/wxxas/xasgui.py
+++ b/larch/wxxas/xasgui.py
@@ -847,7 +847,7 @@ class XASFrame(wx.Frame):
                 gname = tname
 
             cur_panel.skip_plotting = (scan == scanlist[-1])
-            displayname = "%s_scan%s" % (fname, scan)
+            displayname = "%s_scan%s_%s" % (fname, scan, self.last_array_sel_spec['yarr1'])
             if first_group is None:
                 first_group = gname
             self.larch.eval(script.format(group=gname, path=path,


### PR DESCRIPTION
@newville this is a minor pull request for adding the counter name when importing from spec.

Initially my idea was to merge the current `wxlib.columnframe` with the possibility to load the reference channel to `wxlib.specfile_importer`. After having spent few hours on this, I got completely lost in the Wx GUI thing! It's pratically impossible to my brain to understand how to correctly put all the indexes in the Wx panels.

Anyway, you can merge this and if you have time at a certain point it would be great to find a way to have a common GUI "data_importer" panel that is the same for columns files, spec and Athena. We could stick to the layout of the specfile importer one, which seems to me mix both the columnframe and the Athena importer.