### PR TITLE
fix importlib_metadata

### DIFF
--- a/larch/version.py
+++ b/larch/version.py
@@ -17,7 +17,7 @@ import lmfit
 
 try:
     from importlib.metadata import version, PackageNotFoundError
-except (ImportError, PackageNotFoundError):
+except ImportError:
     from importlib_metadata import version, PackageNotFoundError
 try:
     __version__ = version("xraylarch")

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,4 +32,4 @@ pymatgen
 fabio
 pyfai
 pycifrw
-importlib_metadata
+importlib_metadata; python_version < '3.8'


### PR DESCRIPTION
Closes #383

```
python -m pip install xraylarch@git+https://git@github.com/woutdenolf/xraylarch.git@pip_from_github
python -c "import larch"
```

Tested with python 3.7 and 3.8