### PR TITLE
Add EXAFS arrays to CSV export + option for  saving individual files

### DIFF
--- a/larch/io/csvfiles.py
+++ b/larch/io/csvfiles.py
@@ -20,7 +20,7 @@ from larch.utils.strutils import bytes2str, fix_varname
 maketrans = str.maketrans
 
 def groups2csv(grouplist, filename, delim=',',
-               x='energy', y='norm', _larch=None):
+               x='energy', y='norm', individual=False, _larch=None):
     """save data from a list of groups to a CSV file
 
     Arguments
@@ -29,6 +29,7 @@ def groups2csv(grouplist, filename, delim=',',
     filname    name of output file
     x          name of group member to use for `x`
     y          name of group member to use for `y`
+    individual toggle saving individual x/y in separate files
 
     """
     def get_label(grp):
@@ -38,6 +39,20 @@ def groups2csv(grouplist, filename, delim=',',
             if o is not None:
                 return o
         return repr(o)
+    
+    if individual is True:
+        for g in grouplist:
+            label = get_label(g)
+            _x = getattr(g, x)
+            _y = getattr(g, y)
+            outarr = np.array([_x, _y])
+            fnout = f"{filename.split('.csv')[0]}_{label}.csv"
+            header = "\n".join([f"saved {time.ctime()}",
+                                f"saving x array={x}, y array={y}",
+                                f"{label}: {g.filename}"])
+            np.savetxt(fnout, outarr.T, delimiter=delim, header=header)
+            print(f"Wrote group to {fnout}")
+        return
 
     ngroups = len(grouplist)
     x0 = getattr(grouplist[0], x)
@@ -49,6 +64,7 @@ def groups2csv(grouplist, filename, delim=',',
     buff = ["# %d files saved %s" % (len(grouplist), time.ctime()),
             "# saving x array='%s', y array='%s'" % (x, y),
             "# %s: %s" % (labels[1], grouplist[0].filename)]
+    
     for g in grouplist[1:]:
         label = get_label(g)
         buff.append("# %s: %s" % (label, g.filename))

--- a/larch/wxxas/xas_dialogs.py
+++ b/larch/wxxas/xas_dialogs.py
@@ -246,7 +246,7 @@ class OverAbsorptionDialog(wx.Dialog):
         ppanel.conf.draw_legend(show=True)
 
     def GetResponse(self):
-        raise AttributError("use as non-modal dialog!")
+        raise AttributeError("use as non-modal dialog!")
 
 
 class EnergyCalibrateDialog(wx.Dialog):
@@ -577,7 +577,7 @@ overwriting current arrays''')
         ppanel.canvas.draw()
 
     def GetResponse(self):
-        raise AttributError("use as non-modal dialog!")
+        raise AttributeError("use as non-modal dialog!")
 
 class RebinDataDialog(wx.Dialog):
     """dialog for rebinning data to standard XAFS grid"""
@@ -785,7 +785,7 @@ class RebinDataDialog(wx.Dialog):
         ppanel.canvas.draw()
 
     def GetResponse(self):
-        raise AttributError("use as non-modal dialog!")
+        raise AttributeError("use as non-modal dialog!")
 
 class SmoothDataDialog(wx.Dialog):
     """dialog for smoothing data"""
@@ -930,7 +930,7 @@ class SmoothDataDialog(wx.Dialog):
         dgroup = self.dgroup
         dgroup.energy = xdat
         dgroup.mu     = ydat
-        ngroup.journal.add('smooth_command', self.cmd)
+        dgroup.journal.add('smooth_command', self.cmd)
         self.parent.process_normalization(dgroup)
         self.plot_results()
 
@@ -978,7 +978,7 @@ class SmoothDataDialog(wx.Dialog):
         ppanel.canvas.draw()
 
     def GetResponse(self):
-        raise AttributError("use as non-modal dialog!")
+        raise AttributeError("use as non-modal dialog!")
 
 class DeconvolutionDialog(wx.Dialog):
     """dialog for energy deconvolution"""
@@ -1118,7 +1118,7 @@ class DeconvolutionDialog(wx.Dialog):
         ppanel.canvas.draw()
 
     def GetResponse(self):
-        raise AttributError("use as non-modal dialog!")
+        raise AttributeError("use as non-modal dialog!")
 
 class DeglitchDialog(wx.Dialog):
     """dialog for deglitching or removing unsightly data points"""
@@ -1392,7 +1392,7 @@ clear undo history''')
         self.history_message.SetLabel('%i items in history' % (len(self.xmasks)-1))
 
     def GetResponse(self):
-        raise AttributError("use as non-modal dialog!")
+        raise AttributeError("use as non-modal dialog!")
 
 
 SPECCALC_SETUP = """#From SpectraCalc dialog:
@@ -1550,7 +1550,7 @@ class SpectraCalcDialog(wx.Dialog):
             self.parent.ShowFile(groupname=ngroup.groupname)
 
     def GetResponse(self):
-        raise AttributError("use as non-modal dialog!")
+        raise AttributeError("use as non-modal dialog!")
 
 class EnergyUnitsDialog(wx.Dialog):
     """dialog for selecting, changing energy units, forcing data to eV"""

--- a/larch/wxxas/xas_dialogs.py
+++ b/larch/wxxas/xas_dialogs.py
@@ -1666,10 +1666,20 @@ class ExportCSVDialog(wx.Dialog):
         title = "Export Selected Groups"
         wx.Dialog.__init__(self, parent, wx.ID_ANY, title=title)
         self.SetFont(Font(FONTSIZE))
+        self.xchoices = {'Energy': 'energy',
+                         'k': 'k',
+                         'R': 'r',
+                         'q': 'q'}
+
         self.ychoices = {'normalized mu(E)': 'norm',
                          'raw mu(E)': 'mu',
                          'flattened mu(E)': 'flat',
-                         'd mu(E) / dE': 'dmude'}
+                         'd mu(E) / dE': 'dmude',
+                         'chi(k)': 'chi',
+                         'chi(E)': 'chie',
+                         'chi(q)': 'chiq',
+                         '|chi(R)|': 'chir_mag',
+                         'Re[chi(R)]': 'chir_re'}
 
         self.delchoices = {'comma': ',',
                            'space': ' ',
@@ -1679,13 +1689,17 @@ class ExportCSVDialog(wx.Dialog):
         panel = GridPanel(self, ncols=3, nrows=4, pad=2, itemstyle=LEFT)
 
         self.master_group = Choice(panel, choices=groupnames, size=(200, -1))
+        self.xarray_name  = Choice(panel, choices=list(self.xchoices.keys()), size=(200, -1))
         self.yarray_name  = Choice(panel, choices=list(self.ychoices.keys()), size=(200, -1))
         self.del_name     = Choice(panel, choices=list(self.delchoices.keys()), size=(200, -1))
 
         panel.Add(SimpleText(panel, 'Group for Energy Array: '), newrow=True)
         panel.Add(self.master_group)
 
-        panel.Add(SimpleText(panel, 'Array to Export: '), newrow=True)
+        panel.Add(SimpleText(panel, 'X Array to Export: '), newrow=True)
+        panel.Add(self.xarray_name)
+
+        panel.Add(SimpleText(panel, 'Y Array to Export: '), newrow=True)
         panel.Add(self.yarray_name)
 
         panel.Add(SimpleText(panel, 'Delimeter for File: '), newrow=True)
@@ -1702,6 +1716,7 @@ class ExportCSVDialog(wx.Dialog):
         ok = False
         if self.ShowModal() == wx.ID_OK:
             master = self.master_group.GetStringSelection()
+            xarray = self.xchoices[self.xarray_name.GetStringSelection()]
             yarray = self.ychoices[self.yarray_name.GetStringSelection()]
             delim  = self.delchoices[self.del_name.GetStringSelection()]
             ok = True

--- a/larch/wxxas/xas_dialogs.py
+++ b/larch/wxxas/xas_dialogs.py
@@ -1688,11 +1688,15 @@ class ExportCSVDialog(wx.Dialog):
 
         panel = GridPanel(self, ncols=3, nrows=4, pad=2, itemstyle=LEFT)
 
+        self.save_individual_files = Check(panel, default=False, label='Save individual files', action=self.onSaveIndividualFiles)
         self.master_group = Choice(panel, choices=groupnames, size=(200, -1))
-        self.xarray_name  = Choice(panel, choices=list(self.xchoices.keys()), size=(200, -1))
+        self.xarray_name  = Choice(panel, choices=list(self.xchoices.keys()),size=(200, -1))
         self.yarray_name  = Choice(panel, choices=list(self.ychoices.keys()), size=(200, -1))
         self.del_name     = Choice(panel, choices=list(self.delchoices.keys()), size=(200, -1))
 
+
+        panel.Add(self.save_individual_files, newrow=True)
+        
         panel.Add(SimpleText(panel, 'Group for Energy Array: '), newrow=True)
         panel.Add(self.master_group)
 
@@ -1708,19 +1712,23 @@ class ExportCSVDialog(wx.Dialog):
         panel.pack()
         fit_dialog_window(self, panel)
 
+    def onSaveIndividualFiles(self, event=None):
+        save_individual = self.save_individual_files.IsChecked()
+        self.master_group.Enable(not save_individual)
 
     def GetResponse(self, master=None, gname=None, ynorm=True):
         self.Raise()
         response = namedtuple('ExportCSVResponse',
-                              ('ok', 'master', 'yarray', 'delim'))
+                              ('ok', 'individual', 'master', 'xarray', 'yarray', 'delim'))
         ok = False
         if self.ShowModal() == wx.ID_OK:
+            individual = self.save_individual_files.IsChecked()
             master = self.master_group.GetStringSelection()
             xarray = self.xchoices[self.xarray_name.GetStringSelection()]
             yarray = self.ychoices[self.yarray_name.GetStringSelection()]
             delim  = self.delchoices[self.del_name.GetStringSelection()]
             ok = True
-        return response(ok, master, yarray, delim)
+        return response(ok, individual, master, xarray, yarray, delim)
 
 class QuitDialog(wx.Dialog):
     """dialog for quitting, prompting to save project"""

--- a/larch/wxxas/xasgui.py
+++ b/larch/wxxas/xasgui.py
@@ -658,10 +658,11 @@ class XASFrame(wx.Frame):
                 savegroups.append(dgroup)
 
 
-        groups2csv(savegroups, outfile, x='energy', y=res.yarray,
-                   delim=res.delim, _larch=self.larch)
-        self.write_message(f"Exported CSV file {outfile:s}")
-
+            groups2csv(savegroups, outfile, x='energy', y=res.yarray,
+                    delim=res.delim, _larch=self.larch)
+            self.write_message(f"Exported CSV file {outfile:s}")
+        except Exception as err:
+            self.write_message(f"/!\ Failed exporting CSV file /!\: {err}")
     # Athena
     def onExportAthenaProject(self, evt=None):
         groups = []

--- a/larch/wxxas/xasgui.py
+++ b/larch/wxxas/xasgui.py
@@ -657,7 +657,7 @@ class XASFrame(wx.Frame):
             if dgroup not in savegroups:
                 savegroups.append(dgroup)
 
-
+        try:
             groups2csv(savegroups, outfile, x='energy', y=res.yarray,
                     delim=res.delim, _larch=self.larch)
             self.write_message(f"Exported CSV file {outfile:s}")

--- a/larch/wxxas/xasgui.py
+++ b/larch/wxxas/xasgui.py
@@ -658,8 +658,8 @@ class XASFrame(wx.Frame):
                 savegroups.append(dgroup)
 
         try:
-            groups2csv(savegroups, outfile, x='energy', y=res.yarray,
-                    delim=res.delim, _larch=self.larch)
+            groups2csv(savegroups, outfile, x=res.xarray, y=res.yarray,
+                    delim=res.delim, individual=res.individual, _larch=self.larch)
             self.write_message(f"Exported CSV file {outfile:s}")
         except Exception as err:
             self.write_message(f"/!\ Failed exporting CSV file /!\: {err}")


### PR DESCRIPTION
Fixes #328

Here a summary of what I have done:
- added the possibility to export EXAFS arrays to CSV files
- added the option to save x/y arrays individually (in case one want to avoid interpolation to master X grid)
- fixed some previous typos (`AttributError` -> `AttributeError`)

Quick tests seems to pass, but an additional check is welcome.