### PR TITLE
Robust remove dups

### DIFF
--- a/larch/math/utils.py
+++ b/larch/math/utils.py
@@ -176,38 +176,33 @@ def remove_dups(arr, tiny=1.e-7, frac=1.e-6):
     Example
     -------
     >>> x = np.array([0, 1.1, 2.2, 2.2, 3.3])
-    >>> print remove_dups(x)
+    >>> print(remove_dups(x))
     >>> array([ 0.   ,  1.1  ,  2.2,  2.2000001,  3.3  ])
     """
-    if not isinstance(arr, np.ndarray):
-        try:
-            arr = np.array(arr)
-        except:
-            print( 'remove_dups: argument is not an array')
-
-    shape = arr.shape
-    arr   = arr.flatten()
-    npts  = len(arr)
-    dups = []
     try:
-        reps = np.where(abs(arr[1:-1] - arr[:-2]) < tiny)[0].tolist()
-        dups.extend([i+1 for i in reps])
-    except ValueError:
-        pass
-    if abs(arr[-1] - arr[-2]) < tiny:
-        dups.append(npts-1)
-    arr = arr.tolist()
+        arr = np.asarray(arr)
+    except Exception:
+        print('remove_dups: argument is not an array')
+
+    if arr.size <= 1:
+        return arr
+    shape = arr.shape
+    arr = arr.flatten()
+    previous_value = np.nan
+    previous_add = 0
+
+    add = np.zeros(arr.size)
     for i in range(1, len(arr)):
-        t = tiny
-        if i > 0:
-            t = max(tiny, frac*abs(arr[i]-arr[i-1]))
-        if arr[i] - arr[i-1] < tiny:
-            arr[i] = arr[i-1] + t
-    if abs(arr[-1] - arr[-2]) < tiny:
-        arr[-1] = arr[-2] + tiny
-    arr = np.array(arr)
-    arr.shape = shape
-    return arr
+        if not np.isnan(arr[i-1]):
+            previous_value = arr[i-1]
+            previous_add = add[i-1]
+        value = arr[i]
+        if np.isnan(value) or np.isnan(previous_value):
+            continue
+        diff = abs(value - previous_value)
+        if diff < tiny:
+            add[i] = previous_add + max(tiny, frac*diff)
+    return (arr+add).reshape(shape)
 
 
 def remove_nans2(a, b):

--- a/larch/xafs/mback.py
+++ b/larch/xafs/mback.py
@@ -114,6 +114,8 @@ def mback(energy, mu=None, group=None, z=None, edge='K', e0=None, pre1=None, pre
         group = set_xafsGroup(group, _larch=_larch)
 
     energy = remove_dups(energy)
+    if energy.size <= 1:
+        raise ValueError("energy array must have at least 2 points")
     if e0 is None or e0 < energy[1] or e0 > energy[-2]:
         e0 = find_e0(energy, mu, group=group)
 

--- a/larch/xafs/pre_edge.py
+++ b/larch/xafs/pre_edge.py
@@ -121,6 +121,8 @@ def preedge(energy, mu, e0=None, step=None, nnorm=None, nvict=0, pre1=None,
          norm1 = roughly min(150, norm2/3.0), rounded to 5 eV
     """
     energy = remove_dups(energy)
+    if energy.size <= 1:
+        raise ValueError("energy array must have at least 2 points")
     if e0 is None or e0 < energy[1] or e0 > energy[-2]:
         e0 = _finde0(energy, mu)
 

--- a/tests/test_math_utils.py
+++ b/tests/test_math_utils.py
@@ -1,0 +1,36 @@
+import numpy.testing
+from larch.math import utils
+
+
+def test_remove_dups():
+    expected = numpy.array([])
+    calculated = utils.remove_dups([])
+    numpy.testing.assert_array_equal(calculated, expected)
+
+    expected = numpy.array([1])
+    calculated = utils.remove_dups([1])
+    numpy.testing.assert_array_equal(calculated, expected)
+
+    expected = numpy.array([1, 1 + 1e-7])
+    calculated = utils.remove_dups([1, 1])
+    numpy.testing.assert_array_equal(calculated, expected)
+
+    expected = numpy.array([1, 1 + 1e-7, 1 + 2e-7])
+    calculated = utils.remove_dups([1, 1, 1])
+    numpy.testing.assert_array_equal(calculated, expected)
+
+    expected = numpy.array([1, numpy.nan])
+    calculated = utils.remove_dups([1, numpy.nan])
+    numpy.testing.assert_array_equal(calculated, expected)
+
+    expected = numpy.array([1, numpy.nan, 1 + 1e-7])
+    calculated = utils.remove_dups([1, numpy.nan, 1])
+    numpy.testing.assert_array_equal(calculated, expected)
+
+    expected = numpy.array([numpy.nan, 1, 1 + 1e-7])
+    calculated = utils.remove_dups([numpy.nan, 1, 1])
+    numpy.testing.assert_array_equal(calculated, expected)
+
+    expected = numpy.array([[numpy.nan, 1], [1 + 1e-7, 1 + 2e-7]])
+    calculated = utils.remove_dups([[numpy.nan, 1], [1, 1]])
+    numpy.testing.assert_array_equal(calculated, expected)


### PR DESCRIPTION
Exceptions from larch are sometimes cryptic. This MR makes `remove_dups` more robust (+ add tests) and raises explicit exceptions in `pre_edge` and `mback` when there are not enough data points.