### PR TITLE
Remove an unnecessary test expression.

### DIFF
--- a/larch/inputText.py
+++ b/larch/inputText.py
@@ -171,7 +171,7 @@ class HistoryBuffer(object):
         comment = "# %s saved" % (self.title)
         out = ["%s %s" % (comment, time.ctime())]
         for bline in self.buffer[start_:end_]:
-            if not (bline.startswith(comment) or len(bline) < 0):
+            if not (bline.startswith(comment)):
                 out.append(str(bline))
         out.append('')
         return out


### PR DESCRIPTION
In file: inputText.py, the comparison of Collection length creates a logical short circuit. This is a part of a logical OR. Since it is always evaluating to false, it did not have any impact on the code here.


We suggested that the Collection length comparison should be done without creating a logical short circuit. 