### PR TITLE
updated some types depricated in numpy1.20

### DIFF
--- a/larch/io/rixsdata.py
+++ b/larch/io/rixsdata.py
@@ -36,7 +36,7 @@ def _restore_from_array(dictin):
         if isinstance(v, dict):
             _restore_from_array(v)
         else:
-            if isinstance(v[()], np.str):
+            if isinstance(v[()], np.str_):
                 dictin[k] = np.array_str(v)
             if isinstance(v[()], (np.float64, np.float32)):
                 dictin[k] = copy.deepcopy(v.item())

--- a/larch/wxxas/xas_dialogs.py
+++ b/larch/wxxas/xas_dialogs.py
@@ -1254,7 +1254,7 @@ class DeglitchDialog(wx.Dialog):
             plotstr = self.wids['plotopts'].GetStringSelection()
             plottype = DEGLITCH_PLOTS[plotstr]
         self.data = self.get_xydata(datatype=plottype)
-        self.xmasks = [np.ones(len(self.data[0]), dtype=np.bool)]
+        self.xmasks = [np.ones(len(self.data[0]), dtype=np.bool_)]
 
     def get_xydata(self, datatype='mu'):
         if hasattr(self.dgroup, 'energy'):
@@ -1319,7 +1319,7 @@ class DeglitchDialog(wx.Dialog):
 
     def on_undo(self, event=None):
         if len(self.xmasks) == 1:
-            self.xmasks = [np.ones(len(self.data[0]), dtype=np.bool)]
+            self.xmasks = [np.ones(len(self.data[0]), dtype=np.bool_)]
         else:
             self.xmasks.pop()
         self.plot_results()

--- a/larch/wxxas/xas_dialogs.py
+++ b/larch/wxxas/xas_dialogs.py
@@ -1319,7 +1319,7 @@ class DeglitchDialog(wx.Dialog):
 
     def on_undo(self, event=None):
         if len(self.xmasks) == 1:
-            self.xmasks = [np.ones(len(self.data[0]), dtype=np.bool_)]
+            self.xmasks = [np.ones(len(self.data[0]), dtype=np.int8)]
         else:
             self.xmasks.pop()
         self.plot_results()

--- a/larch/wxxas/xas_dialogs.py
+++ b/larch/wxxas/xas_dialogs.py
@@ -1254,7 +1254,7 @@ class DeglitchDialog(wx.Dialog):
             plotstr = self.wids['plotopts'].GetStringSelection()
             plottype = DEGLITCH_PLOTS[plotstr]
         self.data = self.get_xydata(datatype=plottype)
-        self.xmasks = [np.ones(len(self.data[0]), dtype=np.bool_)]
+        self.xmasks = [np.ones(len(self.data[0]), dtype=np.int8)]
 
     def get_xydata(self, datatype='mu'):
         if hasattr(self.dgroup, 'energy'):

--- a/larch/xray/background.py
+++ b/larch/xray/background.py
@@ -200,7 +200,7 @@ class XrayBackground:
         compress = self.compress
 
         nchans   = len(data)
-        self.bgr = np.zeros(nchans, dtype=np.int_)
+        self.bgr = np.zeros(nchans, dtype=np.int32)
         scratch  = data[:]
 
         # Compress scratch spectrum

--- a/larch/xray/background.py
+++ b/larch/xray/background.py
@@ -200,7 +200,7 @@ class XrayBackground:
         compress = self.compress
 
         nchans   = len(data)
-        self.bgr = np.zeros(nchans, dtype=np.int)
+        self.bgr = np.zeros(nchans, dtype=np.int_)
         scratch  = data[:]
 
         # Compress scratch spectrum


### PR DESCRIPTION
**Summary:**
- Fixed some types that were deprecated in Numpy 1.20.
https://numpy.org/doc/stable/release/1.20.0-notes.html#deprecations

**Initial issue:**
The following issue came up when I tried to deglitch the data. The problem was that Numpy had deprecated some other codes that contained deprecated types.

**Error message:**
Traceback (most recent call last):
  File "/Users/ryuichi/mambaforge_x86_64/envs/xraylarch/lib/python3.11/site-packages/larch/wxxas/xasgui.py", line 1012, in onDeglitchData
    DeglitchDialog(self, self.controller).Show()
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/ryuichi/mambaforge_x86_64/envs/xraylarch/lib/python3.11/site-packages/larch/wxxas/xas_dialogs.py", line 1143, in __init__
    self.reset_data_history()
  File "/Users/ryuichi/mambaforge_x86_64/envs/xraylarch/lib/python3.11/site-packages/larch/wxxas/xas_dialogs.py", line 1257, in reset_data_history
    self.xmasks = [np.ones(len(self.data[0]), dtype=np.bool)]
                                                    ^^^^^^^
  File "/Users/ryuichi/mambaforge_x86_64/envs/xraylarch/lib/python3.11/site-packages/numpy/__init__.py", line 305, in __getattr__
    raise AttributeError(__former_attrs__[attr])
AttributeError: module 'numpy' has no attribute 'bool'.
`np.bool` was a deprecated alias for the builtin `bool`. To avoid this error in existing code, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.
The aliases was originally deprecated in NumPy 1.20; for more details and guidance see the original release note at:
    https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations. Did you mean: 'bool_'?