### PR TITLE
Removed hard-coded paths and '../' paths from tests in favor of Pathlib.

### DIFF
--- a/tests/test_larchexamples_basic.py
+++ b/tests/test_larchexamples_basic.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """ Tests of Larch Scripts  """
 import unittest
+from pathlib import Path
 import time
 import ast
 import numpy as np
@@ -9,41 +10,45 @@ from sys import version_info
 
 from utils import TestCase
 from larch import Interpreter
+
+
+base_dir = Path(__file__).parent.parent.resolve()
+
 class TestScripts(TestCase):
     '''tests'''
 
     def test_basic_interp(self):
-        self.runscript('interp.lar', dirname='../examples/basic/')
+        self.runscript('interp.lar', dirname=base_dir / 'examples' / 'basic')
         assert(len(self.session.get_errors()) == 0)
         self.isNear("y0[1]", 0.48578, places=3)
         self.isNear("y1[1]", 0.81310, places=3)
         self.isNear("y2[1]", 0.41532, places=3)
 
     def test_basic_smooth(self):
-        self.runscript('smoothing.lar', dirname='../examples/basic/')
+        self.runscript('smoothing.lar', dirname=base_dir / 'examples' / 'basic')
         assert(len(self.session.get_errors()) == 0)
         self.isNear("s_loren[5]", 0.087, places=2)
         self.isNear("s_gauss[5]", 3.958e-05, places=2)
         self.isNear("s_voigt[5]", 0.0957, places=2)
 
     def test_basic_localnames(self):
-        self.runscript('local_namespaces.lar', dirname='../examples/basic/')
+        self.runscript('local_namespaces.lar', dirname=base_dir / 'examples' / 'basic')
         assert(len(self.session.get_errors()) == 0)
         self.isNear("x", 1000.0, places=4)
 
     def test_basic_pi(self):
-        self.runscript('pi_archimedes.lar', dirname='../examples/basic/')
+        self.runscript('pi_archimedes.lar', dirname=base_dir / 'examples' / 'basic')
         assert(len(self.session.get_errors()) == 0)
         self.isNear("result", 3.14159265358979267, places=8)
 
     def test_basic_use_params(self):
-        self.runscript('use_params.lar', dirname='../examples/basic/')
+        self.runscript('use_params.lar', dirname=base_dir / 'examples' / 'basic')
         assert(len(self.session.get_errors()) == 0)
         self.isNear("a",  0.76863, places=4)
 
     def test_nested_runfiles(self):
-        origdir = os.path.abspath(os.getcwd())
-        dirname = os.path.abspath('larch_scripts')
+        origdir = Path.cwd().absolute()
+        dirname = base_dir / "tests" / "larch_scripts"
         os.chdir(dirname)
         out, err = self.trytext("run('nested_outer.lar')")
 
@@ -57,11 +62,9 @@ class TestScripts(TestCase):
         assert('in nested_outer.lar, after nested_inner' in out[4])
         self.isNear("deep_x",  5.0, places=2)
 
-
-
     def test_runfit(self):
-        origdir = os.path.abspath(os.getcwd())
-        dirname = os.path.abspath('larch_scripts')
+        origdir = Path.cwd().absolute()
+        dirname = base_dir / "tests" / "larch_scripts"
         os.chdir(dirname)
 
         out, err = self.trytext("run('fit_constraint.lar')")

--- a/tests/test_larchexamples_xafs.py
+++ b/tests/test_larchexamples_xafs.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """ Tests of Larch Scripts  """
 import unittest
+from pathlib import Path
 import time
 import ast
 import numpy as np
@@ -8,54 +9,57 @@ from sys import version_info
 
 from utils import TestCase
 from larch import Interpreter
+
+base_dir = Path(__file__).parent.parent.resolve()
+
 class TestScripts(TestCase):
     '''testing of asteval'''
     def test01_basic(self):
-        self.runscript('a.lar', dirname='larch_scripts')
+        self.runscript('a.lar', dirname=base_dir / 'tests' / 'larch_scripts')
         assert(len(self.session.get_errors()) == 0)
         self.isTrue("n < 10")
         self.isTrue("n >  5")
         self.isTrue("x >  3")
 
     def test02_autobk(self):
-        self.runscript('doc_autobk1.lar', dirname='../examples/xafs/')
+        self.runscript('doc_autobk1.lar', dirname=base_dir / 'examples' / 'xafs')
         assert(len(self.session.get_errors()) == 0)
         self.isTrue("cu.e0 > 8950.0")
         self.isTrue("len(cu.k) > 200")
         self.isTrue("max(abs(cu.chi)) < 2.0")
 
     def test03_autobk2(self):
-        self.runscript('doc_autobk2.lar', dirname='../examples/xafs/')
+        self.runscript('doc_autobk2.lar', dirname=base_dir / 'examples' / 'xafs')
         assert(len(self.session.get_errors()) == 0)
         self.isTrue("dat.e0 > 10000.0")
         self.isTrue("len(dat.k) > 200")
 
     def test04_autobk_clamp(self):
-        self.runscript('doc_autobk3.lar', dirname='../examples/xafs/')
+        self.runscript('doc_autobk3.lar', dirname=base_dir / 'examples' / 'xafs')
         assert(len(self.session.get_errors()) == 0)
         self.isTrue("dat.e0 > 11000.0")
         self.isTrue("len(dat.k) > 200")
 
     def test05_autobk_with_std(self):
-        self.runscript('doc_autobk4.lar', dirname='../examples/xafs/')
+        self.runscript('doc_autobk4.lar', dirname=base_dir / 'examples' / 'xafs')
         assert(len(self.session.get_errors()) == 0)
         self.isTrue("cu2.e0 > 8950.0")
         self.isTrue("len(cu2.k) > 200")
         self.isTrue("max(abs(cu2.chi)) < 2.0")
 
     def test06_ftwin1(self):
-        self.runscript('doc_ftwin1.lar', dirname='../examples/xafs/')
+        self.runscript('doc_ftwin1.lar', dirname=base_dir / 'examples' / 'xafs')
         assert(len(self.session.get_errors()) == 0)
         self.isTrue("len(hann_win1) == 401")
         self.isTrue("hann_win3.sum() > 50.0")
 
-        self.runscript('doc_ftwin2.lar', dirname='../examples/xafs/')
+        self.runscript('doc_ftwin2.lar', dirname=base_dir / 'examples' / 'xafs')
         assert(len(self.session.get_errors()) == 0)
         self.isTrue("len(kai_win1) == 401")
         self.isTrue("kai_win1.sum() > 20.0")
 
     def test07_xafsft1(self):
-        self.runscript('doc_xafsft1.lar', dirname='../examples/xafs/')
+        self.runscript('doc_xafsft1.lar', dirname=base_dir / 'examples' / 'xafs')
         assert(len(self.session.get_errors()) == 0)
         self.isTrue("len(d2.k) > 200")
         self.isTrue("len(d2.kwin) > 200")
@@ -63,7 +67,7 @@ class TestScripts(TestCase):
         self.isTrue("where(d1.chir_mag>1)[0][0] > 60")
 
     def test08_xafsft2(self):
-        self.runscript('doc_xafsft2.lar', dirname='../examples/xafs/')
+        self.runscript('doc_xafsft2.lar', dirname=base_dir / 'examples' / 'xafs')
         assert(len(self.session.get_errors()) == 0)
         self.isTrue("len(d3.k) > 200")
         self.isTrue("len(d3.kwin) > 200")
@@ -80,13 +84,13 @@ class TestScripts(TestCase):
 
 
     def test09_xafsft3(self):
-        self.runscript('doc_xafsft3.lar', dirname='../examples/xafs/')
+        self.runscript('doc_xafsft3.lar', dirname=base_dir / 'examples' / 'xafs')
         assert(len(self.session.get_errors()) == 0)
         self.isTrue("len(dat.k) > 200")
         self.isTrue("len(dat.kwin) > 200")
 
     def test10_xafsft3(self):
-        self.runscript('doc_xafsft4.lar', dirname='../examples/xafs/')
+        self.runscript('doc_xafsft4.lar', dirname=base_dir / 'examples' / 'xafs')
         assert(len(self.session.get_errors()) == 0)
         self.isTrue("len(dat.r) > 200")
         self.isTrue("len(dat.rwin) > 200")
@@ -94,13 +98,13 @@ class TestScripts(TestCase):
         self.isTrue("len(dat.chiq_re) > 200")
 
     def test11_wavelet1(self):
-        self.runscript('wavelet_example.lar', dirname='../examples/xafs/')
+        self.runscript('wavelet_example.lar', dirname=base_dir / 'examples' / 'xafs')
         assert(len(self.session.get_errors()) == 0)
         self.isTrue("f.wcauchy_im.shape == (326, 318)")
         self.isTrue("f.wcauchy_mag.sum() > 300")
 
     def test12_feffit_kws(self):
-        self.runscript('test_epsk_kws.lar', dirname='../examples/feffit/')
+        self.runscript('test_epsk_kws.lar', dirname=base_dir / 'examples' / 'feffit')
         assert(len(self.session.get_errors()) == 0)
         out = self.session.run('out')
         for row in out:
@@ -114,7 +118,7 @@ class TestScripts(TestCase):
             self.assertTrue(abs(delr) < 0.1)
 
     def test13_feffit1(self):
-        self.runscript('doc_feffit1.lar', dirname='../examples/feffit/')
+        self.runscript('doc_feffit1.lar', dirname=base_dir / 'examples' / 'feffit')
         assert(len(self.session.get_errors()) == 0)
 
         self.isTrue('out.nfev > 20')
@@ -131,7 +135,7 @@ class TestScripts(TestCase):
         self.isNear('out.paramgroup.sig2.value',    0.0087, places=3)
 
     def test14_feffdat3(self):
-        self.runscript('doc_feffdat3.lar', dirname='../examples/feffit/')
+        self.runscript('doc_feffdat3.lar', dirname=base_dir / 'examples' / 'feffit')
         assert(len(self.session.get_errors()) == 0)
 
         self.isNear('path1.degen',  6.0, places=1)
@@ -154,7 +158,7 @@ class TestScripts(TestCase):
 
 
     def test15_feffit2(self):
-        self.runscript('doc_feffit2.lar', dirname='../examples/feffit/')
+        self.runscript('doc_feffit2.lar', dirname=base_dir / 'examples' / 'feffit')
         assert(len(self.session.get_errors()) == 0)
 
         self.isTrue('out.nfev > 50')
@@ -173,7 +177,7 @@ class TestScripts(TestCase):
 
 
     def test16_feffit3(self):
-        self.runscript('doc_feffit3.lar', dirname='../examples/feffit/')
+        self.runscript('doc_feffit3.lar', dirname=base_dir / 'examples' / 'feffit')
         assert(len(self.session.get_errors()) == 0)
 
         self.isTrue('out.nfev > 15')
@@ -189,8 +193,8 @@ class TestScripts(TestCase):
 
 
     def test17_feffit3extra(self):
-        self.runscript('doc_feffit3.lar', dirname='../examples/feffit/')
-        self.runscript('doc_feffit3_extra.lar', dirname='../examples/feffit/')
+        self.runscript('doc_feffit3.lar', dirname=base_dir / 'examples' / 'feffit')
+        self.runscript('doc_feffit3_extra.lar', dirname=base_dir / 'examples' / 'feffit')
         assert(len(self.session.get_errors()) == 0)
         self.isNear('_ave', 0.005030, places=4)
         self.isNear('_dlo', 0.000315, places=4)

--- a/tests/test_larchexamples_xray.py
+++ b/tests/test_larchexamples_xray.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 """ Tests of Larch Scripts  """
 import unittest
+from pathlib import Path
 import time
 import ast
 import numpy as np
@@ -8,10 +9,14 @@ from sys import version_info
 
 from utils import TestCase
 from larch import Interpreter
+
+
+base_dir = Path(__file__).parent.parent.resolve()
+
 class TestScripts(TestCase):
     '''testing of examples/xray'''
     def test1_mu_elam(self):
-        self.runscript('get_mu_tables.lar', dirname='../examples/xray')
+        self.runscript('get_mu_tables.lar', dirname=base_dir / 'examples' / 'xray')
         assert(len(self.session.get_errors()) == 0)
         self.isTrue("len(mu1) == 401")
         self.isTrue("min(mu1) < 20")
@@ -28,5 +33,3 @@ if __name__ == '__main__':  # pragma: no cover
     for suite in (TestScripts,):
         suite = unittest.TestLoader().loadTestsFromTestCase(suite)
         unittest.TextTestRunner(verbosity=3).run(suite)
-
-

--- a/tests/test_read_beamlinedata.py
+++ b/tests/test_read_beamlinedata.py
@@ -1,8 +1,10 @@
-import os
+from pathlib import Path
 from larch.io import read_ascii, guess_beamline, guess_filereader, read_fdmnes
 
+base_dir = Path(__file__).parent.parent.resolve()
+
 def _tester(fname, return_group=False):
-    fname = os.path.join('..', 'examples', 'xafsdata', 'beamlines', fname)
+    fname =  base_dir / 'examples' / 'xafsdata' / 'beamlines' / fname
     group = read_ascii(fname)
     cls = guess_beamline(group.header)
     bldat = cls(group.header)
@@ -204,7 +206,7 @@ def test_zero_line_header(fname='generic_columns_no_header.dat'):
 
 def test_fdmnes(fnames=['FDMNES_2022_Mo2C_out.dat', 'FDMNES_2022_Mo2C_out_conv.dat']):
     for fname in fnames:
-        fname = os.path.join('..', 'examples', 'xafsdata', 'beamlines', fname)
+        fname =  base_dir / 'examples' / 'xafsdata' / 'beamlines' / fname
         assert(guess_filereader(fname) == 'read_fdmnes')
         group = read_fdmnes(fname)
         assert(group.array_labels == ['energy', 'xanes'])

--- a/tests/test_read_xafsdata.py
+++ b/tests/test_read_xafsdata.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python
 """ Tests of Larch Scripts  """
 
+from pathlib import Path
 from utils import TestCase
 
 class TestScripts(TestCase):
     '''test read_ascii() for all example xafsdata'''
     def test_read_ascii(self):
         # self.symtable.set_symbol('testdir',  os.getcwd())
-        self.runscript('read_ascii.lar', dirname='larch_scripts')
+        dirname = Path(__file__).parent.resolve() / 'larch_scripts'
+        self.runscript('read_ascii.lar', dirname=dirname)
         assert(len(self.session.get_errors()) == 0)
 
         actual = self.session.get_symbol('results')


### PR DESCRIPTION
I tried to run tests and had many of them fail since I was in the top level directory instead of in `tests/`.

Since pytest will parse directories to discover tests, it seemed like a good idea to fix this.

Some tests looked for scripts in "../examples", and these were replaced by checking the path of `__file__` to determine how to get to the examples folder, agnostic to the current working directory.

In doing so, I replaced a few uses of ``os.path`` with ``pathlib.Path`` since I'm more familiar with the latter, but if there's a strong preference for sticking with ``os.path``, I'm not opposed to adding a commit to revert that.