### PR TITLE
kstep detection for xftf

### DIFF
--- a/larch/xafs/xafsft.py
+++ b/larch/xafs/xafsft.py
@@ -224,7 +224,7 @@ def xftr(r, chir=None, group=None, rmin=0, rmax=20, with_phase=False,
 @Make_CallArgs(["k", "chi"])
 def xftf(k, chi=None, group=None, kmin=0, kmax=20, kweight=None,
          dk=1, dk2=None, with_phase=False, window='kaiser', rmax_out=10,
-         nfft=2048, kstep=0.05, _larch=None, **kws):
+         nfft=2048, kstep=None, _larch=None, **kws):
     """
     forward XAFS Fourier transform, from chi(k) to chi(R), using
     common XAFS conventions.
@@ -242,7 +242,7 @@ def xftf(k, chi=None, group=None, kmin=0, kmax=20, kweight=None,
       dk2:      second tapering parameter for FT Window
       window:   name of window type
       nfft:     value to use for N_fft (2048).
-      kstep:    value to use for delta_k (0.05 Ang^-1).
+      kstep:    value to use for delta_k (k[1]-k[0] Ang^-1).
       with_phase: output the phase as well as magnitude, real, imag  [False]
 
     Returns:
@@ -272,6 +272,9 @@ def xftf(k, chi=None, group=None, kmin=0, kmax=20, kweight=None,
     k, chi, group = parse_group_args(k, members=('k', 'chi'),
                                      defaults=(chi,), group=group,
                                      fcn_name='xftf')
+
+    if kstep is None:
+        kstep = k[1] - k[0]
 
     cchi, win  = xftf_prep(k, chi, kmin=kmin, kmax=kmax, kweight=kweight,
                                dk=dk, dk2=dk2, nfft=nfft, kstep=kstep,


### PR DESCRIPTION
The `group.kwin` recorded in the mismatch with the `group.k` when the when the kstep in the `autobk` and `xftf` is different.
This will not affect the calculation of the `R`, since the `R` is calculated using the interpolated `chi(k)` and `kwin`, but it will affect on the plotting.

Sample code to reproduce the problem.
```python
import matplotlib.pyplot as plt
from larch.xafs import pre_edge, autobk, xftf, ftwindow


group = Group()
group.energy = energy
group.mu = mu

pre_edge(group)

# The problem only occurs when we use non-default values for autobk or xftf
autobk(group, kstep=0.1)

# I am using hanning, kmin=2, dk=2 for clarity
xftf(group, window="hanning", kmin=1, dk=1)

correct_kwin = ftwindow(group.k, xmin=1, dx=1)

plt.plot(group.k, group.chi*group.k**2, label='chi(k)')
plt.plot(group.k, group.kwin, label='chi(k)*kwin')
plt.plot(group.k, correct_kwin, label='correct kwin')
plt.legend()
plt.xlim(0, 4)
plt.xlabel('k (A$^{-1}$)')
plt.ylabel('chi(k)')

plt.savefig('xftf.png', dpi=300)
```

Before correction:
![xftf_before_correction](https://github.com/xraypy/xraylarch/assets/77273474/1cbd851c-1a1a-4629-ac95-755f434470c1)

After correction:
![xftf_after_correction](https://github.com/xraypy/xraylarch/assets/77273474/2c7ca62f-5cdc-4838-8571-1b22a0eabcf3)

