### PR TITLE
Disable OpenCL in pyFAI to silent warnings

### DIFF
--- a/larch/__init__.py
+++ b/larch/__init__.py
@@ -33,6 +33,8 @@ try:
 except ImportError:
     pass
 
+import pyFAI
+pyFAI.use_opencl = False
 
 ## be careful here: it is easy to have cicrular imports!
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,4 +39,3 @@ numexpr==2.8.4; python_version < '3.9'
 numexpr>=2.8.7; python_version > '3.8'
 pycifrw
 importlib_metadata; python_version < '3.8'
-pyopencl


### PR DESCRIPTION
With `pyopencl` installed (but no platform available) I get this warning when starting `larch_xrf`:
`WARNING [2023-10-13 15:04:23]: The module pyOpenCL has been imported but can't be used here`

This PR proposes to replace the requirements of `pyopencl` by `pyFAI.use_opencl = False` to silent pyopencl-related warnings.

Indeed, following the issue https://github.com/silx-kit/pyFAI/issues/788:  "use pyFAI without opencl and avoid annoying warnings", PR https://github.com/silx-kit/pyFAI/pull/795 added a `pyFAI.use_config` to toggle pyFAI usage of pyopencl.