### PR TITLE
Improvement on flattening function

### DIFF
--- a/larch/xafs/pre_edge.py
+++ b/larch/xafs/pre_edge.py
@@ -320,32 +320,13 @@ def pre_edge(energy, mu=None, group=None, e0=None, step=None, nnorm=None,
     if p2-p1 < 2:
         p2 = min(len(energy), p1 + 2)
 
-
-    if make_flat and p2-p1 > 4:
-        enx, mux = remove_nans2(energy[p1:p2], norm[p1:p2])
-        # enx, mux = (energy[p1:p2], norm[p1:p2])
-        fpars = Parameters()
-        ncoefs = len(pre_dat['norm_coefs'])
-        fpars.add('c0', value=1.0, vary=True)
-        fpars.add('c1', value=0.0, vary=False)
-        fpars.add('c2', value=0.0, vary=False)
-        if ncoefs > 1:
-            fpars['c1'].set(value=1.e-5, vary=True)
-            if ncoefs > 2:
-                fpars['c2'].set(value=1.e-5, vary=True)
-
-        try:
-            fit = Minimizer(flat_resid, fpars, fcn_args=(enx, mux))
-            result = fit.leastsq()
-            fc0 = result.params['c0'].value
-            fc1 = result.params['c1'].value
-            fc2 = result.params['c2'].value
-
-            flat_diff   = fc0 + energy * (fc1 + energy * fc2)
-            flat        = norm - flat_diff  + flat_diff[ie0]
-            flat[:ie0]  = norm[:ie0]
-        except:
-            pass
+    if make_flat:
+        pre_edge = pre_dat['pre_edge']
+        post_edge = pre_dat['post_edge']
+        edge_step = pre_dat['edge_step']
+        flat_residue = (post_edge - pre_edge)/edge_step
+        flat = norm - flat_residue + flat_residue[ie0]
+        flat[:ie0] = norm[:ie0]
 
     group.e0 = e0
     group.norm = norm


### PR DESCRIPTION
This is a proposed improvement for the flattening function. Currently, the pre-edge flattening function uses a quadric function, regardless of the order selected for pre-edge orders. This occasionally results in artifacts that alter the vertical shift in the flattened spectra, which is undesirable for visual comparisons.

I suggest utilizing the computed pre-edge and post-edge lines to determine the flattened spectra. This algorithm is already implemented in xraytsubaki.

Previous approach:
![image](https://github.com/xraypy/xraylarch/assets/77273474/ae8ed808-46a3-46a3-af4a-b921383fe8e3)

Proposed approach:
![image](https://github.com/xraypy/xraylarch/assets/77273474/b6835137-ac23-4872-9528-b3e98b585ec3)
