### PR TITLE
Fix typos in `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -41,7 +40,6 @@ install_requires =
     scipy>=1.7
     uncertainties>=3.1.4
     lmfit>=1.2.1
-    uncertainties>=3.1
     pyshortcuts>=1.9.0
     xraydb>=4.5
     silx>=0.15.2


### PR DESCRIPTION
This PR proposes to fix small typos in `setup.cfg`: Python3.7 no longer supported and duplicated `uncertainties` dependency.