### PR TITLE
Fix larchapps

### DIFF
--- a/larch/apps.py
+++ b/larch/apps.py
@@ -109,8 +109,6 @@ LarchApps = {
 
     'Larix': LarchApp(name='Larix', script='larix', icon='onecone',
                       description='XANES and EXAFS Analysis GUI for Larch'),
-    'XAS Viewer': LarchApp(name='XAS Viewer', script='larix', icon='onecone',
-                           description='XANES and EXAFS Analysis GUI for Larch'),
     'XRFMap Viewer': LarchApp(name='XRFMap Viewer', script='gse_mapviewer',
                               icon='gse_xrfmap', filetype='XRM Map File (.h5)',
                               description='XRFMap Viewing and Analysis'),

--- a/larch/io/save_restore.py
+++ b/larch/io/save_restore.py
@@ -251,7 +251,7 @@ def load_session(fname, ignore_groups=None, include_xasgroups=None, _larch=None,
         1. data in the following groups will be merged into existing session groups:
            `_feffpaths` : dict of "current feff paths"
            `_feffcache` : dict with cached feff paths and feff runs
-           `_xasgroups` : dict mapping "File Name" and "Group Name", used in `XAS Viewer`
+           `_xasgroups` : dict mapping "File Name" and "Group Name", used in `Larix`
 
         2. to avoid name clashes, group and file names in the `_xasgroups` dictionary
            may be modified on loading

--- a/larch/plot/plotly_xafsplots.py
+++ b/larch/plot/plotly_xafsplots.py
@@ -970,7 +970,7 @@ def plot_prepeaks_baseline(dgroup, subtract_baseline=False, show_fitrange=True,
 
 def plot_prepeaks_fit(dgroup, nfit=0, show_init=False, subtract_baseline=False,
                       show_residual=False):
-    """plot pre-edge peak fit, as from XAS Viewer
+    """plot pre-edge peak fit, as from Larix
 
     dgroup must have a 'peakfit_history' attribute
     """

--- a/larch/wxxas/xas_dialogs.py
+++ b/larch/wxxas/xas_dialogs.py
@@ -1771,7 +1771,7 @@ class QuitDialog(wx.Dialog):
     """dialog for quitting, prompting to save project"""
 
     def __init__(self, parent, message, **kws):
-        title = "Quit Larch XAS Viewer?"
+        title = "Quit Larch Larix?"
         wx.Dialog.__init__(self, parent, wx.ID_ANY, title=title, size=(500, 150))
         self.SetFont(Font(FONTSIZE))
         self.needs_save = True


### PR DESCRIPTION
Removing "XAS viewer" from Larch apps, otherwise duplicated icons are made with `larch -m` command. This is confusing for the new user, as the current name of the Larch GUI is Larix.