### PR TITLE
Bug fix for using feff6l and feff8l

### DIFF
--- a/larch/xafs/feffrunner.py
+++ b/larch/xafs/feffrunner.py
@@ -14,6 +14,8 @@ from larch import Group, isNamedClass
 from larch.utils import isotime, bytes2str, uname, bindir, get_cwd
 
 def find_exe(exename):
+    if isinstance(exename, Path):
+        exename = str(exename)
     if uname == 'win' and not exename.endswith('.exe'):
         exename = f"{exename}.exe"
     exefile = Path(bindir, exename)


### PR DESCRIPTION
@newville 

I noticed a bug when I was using the `feff6l` and `feff8l` functions from `larch.xafs.feffrunner` in my Jupyter Notebook. This is due the `find_exe` function only accept a string as argument, instead of a pathlib.Path object. This fix should solve the problem.

Error message:
```plaintext
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[2], line 1
----> 1 feff6l(feffinp = 'feff.inp', folder = './feff6l', verbose = True)

File ~\Documents\GitHub\xraylarch\larch\xafs\feffrunner.py:257, in feff6l(feffinp, folder, verbose, _larch, **kws)
    254 feffrunner = FeffRunner(folder=folder, feffinp=feffinp, verbose=verbose,
    255                         _larch=_larch, **kws)
    256 exe = find_exe('feff6l')
--> 257 feffrunner.run(exe=exe)
    258 return feffrunner

File ~\Documents\GitHub\xraylarch\larch\xafs\feffrunner.py:134, in FeffRunner.run(self, feffinp, folder, exe)
    131 if exe in self.Feff8l_modules:
    132     exe = f"feff8l_{exe}"
--> 134 resolved_exe = find_exe(exe)
    135 if resolved_exe is not None:
    136     program = resolved_exe

File ~\Documents\GitHub\xraylarch\larch\xafs\feffrunner.py:19, in find_exe(exename)
     16 def find_exe(exename):
     17     # if isinstance(exename, Path):
     18     #     exename = str(exename)
---> 19     if uname == 'win' and not exename.endswith('.exe'):
     20         exename = f"{exename}.exe"
     21     exefile = Path(bindir, exename)

AttributeError: 'WindowsPath' object has no attribute 'endswith'
```