### PR TITLE
small change to athena project writing for consistency with Athena

### DIFF
--- a/larch/io/athena_project.py
+++ b/larch/io/athena_project.py
@@ -149,6 +149,8 @@ def make_athena_args(group, hashkey=None, **kws):
         args[k] = v
 
     args['datagroup'] = args['tag'] = args['label'] = hashkey
+    if not group.__name__.startswith('0x'):
+        args['label'] = group.__name__    
     en = getattr(group, 'energy', [])
     args['npts'] = len(en)
     if len(en) > 0:


### PR DESCRIPTION
If a Larch group is created with a name, i.e.
   g=Group(name='my data')
then the group's name will be used as the label when exporting that group to an Athena project file.  Because the name, if provided, presumably carries semantic information about the data, it is a better choice for the Athena label than Athena's silly 5-letter "hash key", which is was never intended to be used in a semantic context.

If the Larch group is not explicitly named, then the label will default to the 5-letter hash key, which is the current behavior.