### PR TITLE
Drop pandas dependencies + remove by test created files

### DIFF
--- a/larch/math/deglitch.py
+++ b/larch/math/deglitch.py
@@ -218,5 +218,5 @@ def remove_spikes_pandas(y, window=3, threshold=3):
     ------
     ynew : array like x/y
     """
-    _logger.warning("pandas backend is not supported, using numpy instead")
-    return remove_spikes_numpy(y, window=window, threshold=threshold)
+    _logger.warning("pandas backend is not supported, using scipy instead")
+    return remove_spikes_scipy(y, window=window, threshold=threshold)

--- a/larch/math/deglitch.py
+++ b/larch/math/deglitch.py
@@ -7,6 +7,7 @@
 """
 import logging
 import numpy as np
+from scipy.ndimage import median_filter
 
 _logger = logging.getLogger(__name__)
 
@@ -119,8 +120,42 @@ def remove_spikes_pymca(y_spiky, kernel_size=9, threshold=0.66):
     return ynew
 
 
+def remove_spikes_numpy(y, window=3, threshold=3):
+    """remove spikes using numpy
+
+    Parameters
+    ----------
+    y : array 1D
+    window : int (optional)
+        window in rolling median [3]
+    threshold : int (optional)
+        number of sigma difference with original data
+
+    Return
+    ------
+    ynew : array like x/y
+    """
+    ynew = np.zeros_like(y)
+    if window % 2 == 0:
+        window += 1
+        _logger.warning("'window' must be odd -> adjusted to %d", window)
+    try:
+        yf = median_filter(y, size=window, mode='nearest')
+        diff = yf - y
+        mean = diff.mean()
+        sigma = np.sqrt(np.sum((y - mean) ** 2) / len(y))
+        ynew = np.where(abs(diff) > threshold * sigma, yf, y)
+    except Exception as e:
+        _logger.error("Error in remove_spikes_pandas: %s", e)
+        return ynew
+    return ynew
+
+
 def remove_spikes_pandas(y, window=3, threshold=3):
-    """remove spikes using pandas
+    """
+    DEPRECATED:
+
+    remove spikes using pandas
 
     Taken from `https://ocefpaf.github.io/python4oceanographers/blog/2015/03/16/outlier_detection/`_
 
@@ -140,37 +175,5 @@ def remove_spikes_pandas(y, window=3, threshold=3):
     ------
     ynew : array like x/y
     """
-    ynew = np.zeros_like(y)
-    try:
-        import pandas as pd
-    except ImportError:
-        _logger.error("pandas not found! -> returning zeros")
-        return ynew
-    df = pd.DataFrame(y)
-    try:
-        yf = (
-            pd.rolling_median(df, window=window, center=True)
-            .fillna(method="bfill")
-            .fillna(method="ffill")
-        )
-        diff = yf.as_matrix() - y
-        mean = diff.mean()
-        sigma = (y - mean) ** 2
-        sigma = np.sqrt(sigma.sum() / float(len(sigma)))
-        ynew = np.where(abs(diff) > threshold * sigma, yf.as_matrix(), y)
-    except Exception:
-        yf = (
-            df.rolling(window, center=True)
-            .median()
-            .fillna(method="bfill")
-            .fillna(method="ffill")
-        )
-
-        diff = yf.values - y
-        mean = diff.mean()
-        sigma = (y - mean) ** 2
-        sigma = np.sqrt(sigma.sum() / float(len(sigma)))
-        ynew = np.where(abs(diff) > threshold * sigma, yf.values, y)
-
-        # ynew = np.array(yf.values).reshape(len(x))
-    return ynew
+    _logger.warning("pandas backend is not supported, using numpy instead")
+    return remove_spikes_numpy(y, window=window, threshold=threshold)

--- a/larch/xrd/struct2xas.py
+++ b/larch/xrd/struct2xas.py
@@ -29,14 +29,6 @@ from larch.io import read_ascii
 from larch.math.convolution1D import lin_gamma, conv
 
 try:
-    import pandas as pd
-    from pandas.io.formats.style import Styler
-
-    HAS_PANDAS = True
-except ImportError:
-    HAS_PANDAS = False
-
-try:
     import py3Dmol
 
     HAS_PY3DMOL = True
@@ -474,17 +466,9 @@ class Struct2XAS:
             "idx_in_struct",
         ]
         abs_sites = self.get_abs_sites()
-        if HAS_PANDAS:
-            df = pd.DataFrame(
-                abs_sites,
-                columns=header,
-            )
-            df = Styler(df).hide(axis="index")
-            return df
-        else:
-            matrix = [header]
-            matrix.extend(abs_sites)
-            _pprint(matrix)
+        matrix = [header]
+        matrix.extend(abs_sites)
+        _pprint(matrix)
 
     def get_atoms_from_abs(self, radius):
         """Get atoms in sphere from absorbing atom with certain radius"""
@@ -744,13 +728,9 @@ class Struct2XAS:
         )
         print(coord_sym)
         header = ["Element", "Distance"]
-        if HAS_PANDAS:
-            df = pd.DataFrame(data=elems_dist, columns=header)
-            return df
-        else:
-            matrix = [header]
-            matrix.extend(elems_dist)
-            _pprint(matrix)
+        matrix = [header]
+        matrix.extend(elems_dist)
+        _pprint(matrix)
 
     def make_cluster(self, radius):
         """Create a cluster with absorber atom site at the center.
@@ -942,7 +922,7 @@ class Struct2XAS:
                     np.allclose(unique_sites[i][0].coords, selected_site[4], atol=0.01)
                     is True
                 ):
-                    replacements["absorber"] = f"absorber\n{i+1}"
+                    replacements["absorber"] = f"absorber\n{i + 1}"
 
             # absorber = f"{absorber}"
             # replacements["absorber"] = f"Z_absorber\n{round(Element(elem).Z)}"
@@ -963,7 +943,7 @@ class Struct2XAS:
             absorber = f"{absorber}"
             for i in range(len(atoms)):
                 if np.allclose(atoms[i][1], [0, 0, 0], atol=0.01) is True:
-                    replacements["absorber"] = f"absorber\n{i+1}"
+                    replacements["absorber"] = f"absorber\n{i + 1}"
 
             replacements["group"] = ""
 
@@ -1210,7 +1190,7 @@ class Struct2XAS:
         for i in range(len(at)):
             if self.full_occupancy:
                 atoms += "\n" + (
-                    f"{at[i][0][0]:10.6f} {at[i][0][1]:10.6f} {at[i][0][2]:10.6f} {  int(at[i][1])}  {at[i][2]:>5} {at[i][3]:10.5f}         *1 "
+                    f"{at[i][0][0]:10.6f} {at[i][0][1]:10.6f} {at[i][0][2]:10.6f} {int(at[i][1])}  {at[i][2]:>5} {at[i][3]:10.5f}         *1 "
                 )
             else:
                 choice = np.random.choice(

--- a/tests/test_athena_addgroup.py
+++ b/tests/test_athena_addgroup.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 from larch.io import read_ascii, AthenaProject
 
 
@@ -15,4 +15,4 @@ def test_add_athena_group():
     p.save()
 
     # remove file after test
-    os.remove('x1.prj')
+    Path('x1.prj').unlink(missing_ok=True)

--- a/tests/test_athena_addgroup.py
+++ b/tests/test_athena_addgroup.py
@@ -1,3 +1,4 @@
+import numpy.testing
 from pathlib import Path
 from larch.io import read_ascii, AthenaProject
 

--- a/tests/test_athena_addgroup.py
+++ b/tests/test_athena_addgroup.py
@@ -1,4 +1,4 @@
-import numpy.testing
+import os
 from larch.io import read_ascii, AthenaProject
 
 
@@ -9,8 +9,10 @@ def test_add_athena_group():
     b.filename = 'cu_10k_copy.xmu'
     del b.mu
 
-
     p = AthenaProject('x1.prj')
     p.add_group(a)
     p.add_group(b)
     p.save()
+
+    # remove file after test
+    os.remove('x1.prj')

--- a/tests/test_larchexamples_xafs.py
+++ b/tests/test_larchexamples_xafs.py
@@ -6,7 +6,6 @@ import time
 import ast
 import numpy as np
 from sys import version_info
-import os
 
 from utils import TestCase
 from larch import Interpreter
@@ -202,9 +201,9 @@ class TestScripts(TestCase):
 
 
 def test_remove_files():
-    os.remove('../examples/feffit/doc_feffit1.out')
-    os.remove('../examples/feffit/doc_feffit2.out')
-    os.remove('../examples/feffit/doc_feffit3.out')
+    created_test_files = ['doc_feffit1.out', 'doc_feffit2.out', 'doc_feffit3.out']
+    for file in created_test_files:
+        (base_dir / 'examples' / 'feffit' / file).unlink(missing_ok=True)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/tests/test_larchexamples_xafs.py
+++ b/tests/test_larchexamples_xafs.py
@@ -6,6 +6,7 @@ import time
 import ast
 import numpy as np
 from sys import version_info
+import os
 
 from utils import TestCase
 from larch import Interpreter
@@ -200,6 +201,10 @@ class TestScripts(TestCase):
         self.isNear('_dlo', 0.000315, places=4)
 
 
+def test_remove_files():
+    os.remove('../examples/feffit/doc_feffit1.out')
+    os.remove('../examples/feffit/doc_feffit2.out')
+    os.remove('../examples/feffit/doc_feffit3.out')
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/tests/test_math_deglitch.py
+++ b/tests/test_math_deglitch.py
@@ -1,5 +1,5 @@
 import numpy as np
-from larch.math.deglitch import remove_spikes_numpy, remove_spikes_pandas
+from larch.math.deglitch import remove_spikes_numpy, remove_spikes_pandas, remove_spikes_scipy
 
 
 def test_remove_spikes_numpy():
@@ -10,6 +10,19 @@ def test_remove_spikes_numpy():
 
     # Run the function
     result = remove_spikes_numpy(y, window=3, threshold=3)
+
+    # Check if all elements in result are smaller than 5
+    assert np.all(result < 5), "Test failed: spikes not detected"
+
+
+def test_remove_spikes_scipy():
+    # Input array with spikes
+    y = np.random.random(100)
+    y[24] = 10
+    y[56] = 11
+
+    # Run the function
+    result = remove_spikes_scipy(y, window=3, threshold=3)
 
     # Check if all elements in result are smaller than 5
     assert np.all(result < 5), "Test failed: spikes not detected"

--- a/tests/test_math_deglitch.py
+++ b/tests/test_math_deglitch.py
@@ -1,0 +1,28 @@
+import numpy as np
+from larch.math.deglitch import remove_spikes_numpy, remove_spikes_pandas
+
+
+def test_remove_spikes_numpy():
+    # Input array with spikes
+    y = np.random.random(100)
+    y[24] = 10
+    y[56] = 11
+
+    # Run the function
+    result = remove_spikes_numpy(y, window=3, threshold=3)
+
+    # Check if all elements in result are smaller than 5
+    assert np.all(result < 5), "Test failed: spikes not detected"
+
+
+def test_remove_spikes_pandas():
+    # Input array with spikes
+    y = np.random.random(100)
+    y[24] = 10
+    y[56] = 11
+
+    # Run the function
+    result = remove_spikes_pandas(y, window=3, threshold=3)
+
+    # Check if all elements in result are smaller than 5
+    assert np.all(result < 5), "Test failed: spikes not detected"

--- a/tests/test_symbol_callbacks.py
+++ b/tests/test_symbol_callbacks.py
@@ -1,7 +1,10 @@
 from larch import Interpreter
 linp = Interpreter()
+
+
 def onVarChange(group=None, symbolname=None, value=None, **kws):
-    print( 'var changed ', group, symbolname, value, kws)
+    print('var changed ', group, symbolname, value, kws)
+
 
 linp('x = 100.0')
 linp.symtable.set_symbol('x', 30)


### PR DESCRIPTION
As mentioned in #545, this PR drops pandas.

1dd740f175a25f1628b451e2f90bb9f06e6da73c substitutes the `remove_spikes_pandas()`  with a `numpy` version: `remove_spikes_numpy()` in `math/deglitch.py`. Added a test for this as well. The result works quite well:

<img width="871" alt="numpy" src="https://github.com/user-attachments/assets/c560d522-9351-47b3-adda-487e047a68a1" />

b2ddb0d24867699c381631dbca4a3a7c362cdf4e remove the pandas dependencyin `xrd/instruct2xas.py`. 

a6094a796de7f5b064617636358708661ace9565 and 0c449c737fc2ee5c7b56039beccb1b5b408ba68c remove the by `pytest` created test files. 

0c449c737fc2ee5c7b56039beccb1b5b408ba68c is just a stylistic cleanup. 

All tests are passing on `platform darwin -- Python 3.12.0, pytest-8.3.4`