### PR TITLE
Fix a bug in mback_norm method of mback.py

### DIFF
--- a/larch/xafs/mback.py
+++ b/larch/xafs/mback.py
@@ -256,7 +256,7 @@ def mback_norm(energy, mu=None, group=None, z=None, edge='K', e0=None,
 
     if _larch is not None:
         group = set_xafsGroup(group, _larch=_larch)
-    group.norm_poly = group.norm*1.0
+        group.norm_poly = group.norm*1.0
 
     if z is not None:              # need to run find_e0:
         e0_nominal = xray_edge(z, edge).energy

--- a/larch/xafs/mback.py
+++ b/larch/xafs/mback.py
@@ -256,7 +256,12 @@ def mback_norm(energy, mu=None, group=None, z=None, edge='K', e0=None,
 
     if _larch is not None:
         group = set_xafsGroup(group, _larch=_larch)
-        group.norm_poly = group.norm*1.0
+
+    if getattr(group, 'pre_edge_details', None) is None:  # pre_edge never run
+        pre_edge(group, pre1=pre1, pre2=pre2, nvict=nvict,
+                norm1=norm1, norm2=norm2, e0=e0, nnorm=nnorm)
+
+    group.norm_poly = group.norm*1.0
 
     if z is not None:              # need to run find_e0:
         e0_nominal = xray_edge(z, edge).energy
@@ -273,9 +278,6 @@ def mback_norm(energy, mu=None, group=None, z=None, edge='K', e0=None,
     if atsym is None and z is not None:
         atsym = atomic_symbol(z)
 
-    if getattr(group, 'pre_edge_details', None) is None:  # pre_edge never run
-        pre_edge(group, pre1=pre1, pre2=pre2, nvict=nvict,
-                norm1=norm1, norm2=norm2, e0=e0, nnorm=nnorm)
     if pre1 is None:
         pre1 = group.pre_edge_details.pre1
     if pre2 is None:


### PR DESCRIPTION
Found an issue where mback_norm couldn't be used without a previous call to pre_edge, because the "norm" attribute was not already in the group. It appears that there was a typo where one line was intended to be part of an if statement.