### PR TITLE
[Larix] show session file name in main window title

### DIFF
--- a/larch/wxxas/xas_controller.py
+++ b/larch/wxxas/xas_controller.py
@@ -22,6 +22,7 @@ from larch.site_config import home_dir, user_larchdir
 
 from .config import XASCONF, CONF_FILE,  OLDCONF_FILE
 
+
 class XASController():
     """
     class holding the Larch session and doing the processing work for Larix
@@ -59,11 +60,10 @@ class XASController():
         if not Path(self.larix_folder).exists():
             try:
                 mkdir(self.larix_folder)
-            except:
+            except Exception:
                 title = "Cannot create Larix folder"
                 message = [f"Cannot create directory {larix_folder}"]
                 ExceptionPopup(self, title, message)
-
 
         # may migrate old 'xas_viewer.conf' file to 'larix.conf'
         old_config_file = Path(self.larix_folder, OLDCONF_FILE).as_posix()
@@ -85,7 +85,6 @@ class XASController():
         self.config = self.larch.symtable._sys.larix_config = config
         self.larch.symtable._sys.wx.plotopts = config['plot']
         self.clean_autosave_sessions()
-
 
     def install_group(self, groupname, filename, source=None, journal=None):
         """add groupname / filename to list of available data groups"""
@@ -210,7 +209,7 @@ class XASController():
         try:
             with open(Path(self.larix_folder, 'workdir.txt'), 'w') as fh:
                 fh.write(f"{get_cwd()}\n")
-        except:
+        except Exception:
             pass
 
         buffer = []
@@ -225,7 +224,7 @@ class XASController():
         try:
             with open(Path(self.larix_folder, 'recent_sessions.txt'), 'w') as fh:
                 fh.write(buffer)
-        except:
+        except Exception:
             pass
 
     def init_workdir(self):
@@ -237,11 +236,11 @@ class XASController():
                     with open(wfile, 'r') as fh:
                         workdir = fh.readlines()[0][:-1]
                         self.config['main']['workdir'] = workdir
-                except:
+                except Exception:
                     pass
             try:
                 os.chdir(self.config['main']['workdir'])
-            except:
+            except Exception:
                 pass
 
         rfile = Path(self.larix_folder, 'recent_sessions.txt')
@@ -253,7 +252,7 @@ class XASController():
                     try:
                         w = line[:-1].split(None, maxsplit=1)
                         self.recentfiles.insert(0, (float(w[0]), w[1]))
-                    except:
+                    except Exception:
                         pass
 
     def register_group_callback(self, label, obj, callback):
@@ -271,11 +270,10 @@ class XASController():
                 obj, cb = val
                 obj.Raise()
                 cb()
-            except:
+            except Exception:
                 missing.append(key)
         for key in missing:
             self.unregister_group_callback(key)
-
 
     def autosave_session(self):
         conf = self.get_config('autosave', {})
@@ -310,7 +308,7 @@ class XASController():
                     try:
                         version = int(words[-1])
                         words.pop()
-                    except:
+                    except Exception:
                         version = 0
                     dat.append((ffile.as_posix(), version, mtime))
             return sorted(dat, key=lambda x: x[2])
@@ -349,7 +347,6 @@ class XASController():
                 flist.append((os.stat(ffile).st_mtime, ffile))
 
         return sorted(flist, key=lambda x: x[0], reverse=True)[:max_hist]
-
 
     def clear_session(self):
         self.larch.eval("clear_session()")

--- a/larch/wxxas/xas_dialogs.py
+++ b/larch/wxxas/xas_dialogs.py
@@ -549,6 +549,8 @@ class LoadSessionDialog(wx.Frame):
 
         self.controller.recentfiles.append((time.time(), self.filename))
 
-        wx.CallAfter(self.Destroy)
+        #wx.CallAfter(self.Destroy)
         if last_fname is not None:
             self.parent.ShowFile(filename=last_fname)
+
+        self.Destroy()

--- a/larch/wxxas/xasgui.py
+++ b/larch/wxxas/xasgui.py
@@ -866,6 +866,8 @@ class LarixFrame(wx.Frame):
 
     def onSetTitle(self, savefile=None):
         """set title of main window"""
+        if savefile is None:
+            savefile = self.controller.autosave_session()
         if savefile is not None:
             self.SetTitle(f"Larix [{Path(savefile).name}]")
         else:
@@ -1045,6 +1047,8 @@ class LarixFrame(wx.Frame):
             os.chdir(fdir)
             self.controller.set_workdir()
 
+        self.onSetTitle()
+
     def onSaveSessionAs(self, evt=None):
         groups = self.controller.filelist.GetItems()
         if len(groups) < 1:
@@ -1082,6 +1086,7 @@ class LarixFrame(wx.Frame):
         self.last_save_message = ("Session last saved", f"'{fname}'", f"{stime}")
         self.write_message(f"Saved session to '{fname}' at {stime}")
         self.last_session_file = self.last_session_read = fname
+        self.onSetTitle()
 
     def onClearSession(self, evt=None):
         conf = self.controller.get_config('autosave',

--- a/larch/wxxas/xasgui.py
+++ b/larch/wxxas/xasgui.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from importlib import import_module
 from threading import Thread
 import numpy as np
-np.seterr(all='ignore')
 
 from functools import partial
 
@@ -76,6 +75,8 @@ from larch.io.xas_data_source import open_xas_source
 
 from .larix_app import LARIX_TITLE
 
+np.seterr(all='ignore')
+
 # FNB_STYLE = flat_nb.FNB_NO_X_BUTTON
 FNB_STYLE = flat_nb.FNB_X_ON_TAB
 FNB_STYLE |= flat_nb.FNB_SMART_TABS|flat_nb.FNB_NO_NAV_BUTTONS
@@ -91,6 +92,7 @@ PLOTWIN_SIZE = (550, 550)
 
 QUIT_MESSAGE = '''Really Quit? You may want to save your project before quitting.
  This is not done automatically!'''
+
 
 def assign_gsescan_groups(group):
     labels = group.array_labels
@@ -250,6 +252,7 @@ class PreferencesFrame(wx.Frame):
         self.controller.config['main']['panels'] = current_panels
         self.controller.save_config()
 
+
 class PanelSelectionPanel(wx.Panel):
     """panel for Preferences Frame to select analysis tabs/panels to display"""
     def __init__(self, parent, main, controller, **kws):
@@ -260,7 +263,7 @@ class PanelSelectionPanel(wx.Panel):
 
         self.wids = {}
 
-        style    = wx.DEFAULT_FRAME_STYLE|wx.TAB_TRAVERSAL
+        style     = wx.DEFAULT_FRAME_STYLE|wx.TAB_TRAVERSAL
         labstyle  = wx.ALIGN_LEFT|wx.ALIGN_CENTER_VERTICAL|wx.ALL
         rlabstyle = wx.ALIGN_RIGHT|wx.ALIGN_CENTER_VERTICAL|wx.ALL
         tstyle    = wx.ALIGN_LEFT|wx.ALIGN_CENTER_VERTICAL
@@ -358,13 +361,13 @@ class PanelSelectionPanel(wx.Panel):
             if name in selections:
                 try:
                     self.main.add_analysis_panel(name)
-                except:
+                except Exception:
                     pass
         for name in selections:
             if name not in cur_panels:
                 try:
                     self.main.add_analysis_panel(name)
-                except:
+                except Exception:
                     pass
         self.main.nb.SetSelection(0)
         self.main.mode = self.current_mode
@@ -376,6 +379,7 @@ class LarixFrame(wx.Frame):
     _about = f"""{LARIX_TITLE}
     Matt Newville <newville @ cars.uchicago.edu>
     """
+
     def __init__(self, parent=None, _larch=None, filename=None,
                  with_wx_inspect=False, mode=None, check_version=True, **kws):
         wx.Frame.__init__(self, parent, -1, size=LARIX_SIZE, style=FRAMESTYLE)
@@ -394,7 +398,6 @@ class LarixFrame(wx.Frame):
         self.last_athena_file = None
         self.paths2read = []
         self.current_filename = filename
-        title = LARIX_TITLE
 
         self.larch_buffer = parent
         if not isinstance(parent, LarchFrame):
@@ -418,9 +421,9 @@ class LarixFrame(wx.Frame):
         iconfile = Path(icondir, ICON_FILE).as_posix()
         self.SetIcon(wx.Icon(iconfile, wx.BITMAP_TYPE_ICO))
 
+        savefile = Path(self.controller.autosave_session())
         self.last_autosave = 0
         self.last_save_message = ('Session has not been saved', '', '')
-
 
         self.timers = {'pin': wx.Timer(self),
                        'autosave': wx.Timer(self)}
@@ -429,6 +432,7 @@ class LarixFrame(wx.Frame):
         self.cursor_dat = {}
 
         self.subframes = {}
+        title = f"Larix [{savefile.name}]"
         self.SetTitle(title)
         self.SetSize(LARIX_SIZE)
         self.SetMinSize(LARIX_MINSIZE)
@@ -467,7 +471,6 @@ class LarixFrame(wx.Frame):
             wx.CallAfter(self.onShowLarchBuffer)
 
         self.Raise()
-
 
     def createMainPanel(self):
         display0 = wx.Display(0)
@@ -538,7 +541,7 @@ class LarixFrame(wx.Frame):
             if panelname in LARIX_PANELS:
                 try:
                     self.add_analysis_panel(panelname)
-                except:
+                except Exception:
                     pass
         self.nb.SetSelection(0)
 
@@ -582,7 +585,7 @@ class LarixFrame(wx.Frame):
             cls = getattr(import_module(module), clsname)
             nbpanel = cls(parent=self, controller=self.controller)
             self.nb.AddPage(nbpanel, atab.title, True)
-        except:
+        except Exception:
             print(f"cannot use analysis panel {atab}:")
             traceback.print_exception(sys.exception())
 
@@ -703,7 +706,7 @@ class LarixFrame(wx.Frame):
             pagepanel.fill_form(dgroup)
             pagepanel.process(dgroup=dgroup)
 
-        if plot=='yes' and hasattr(pagepanel, 'plot'):
+        if plot == 'yes' and hasattr(pagepanel, 'plot'):
             pagepanel.plot(dgroup=dgroup)
             pagepanel.skip_process = False
 
@@ -735,7 +738,6 @@ class LarixFrame(wx.Frame):
         MenuItem(self, file_menu, "&Save Larch Session As ...\tCtrl+A",
                  "Save Session to a File",  self.onSaveSessionAs)
 
-
         file_menu.AppendSeparator()
         MenuItem(self, file_menu, "Save Selected Groups to Athena Project File",
                  "Save Selected Groups to an Athena Project File",
@@ -746,7 +748,6 @@ class LarixFrame(wx.Frame):
                  self.onExportCSV)
 
         MenuItem(self, file_menu, "&Quit\tCtrl+Q", "Quit program", self.onClose)
-
 
         MenuItem(self, session_menu, "&Read Larch Session",
                  "Read Previously Saved Session",  self.onLoadSession)
@@ -768,7 +769,6 @@ class LarixFrame(wx.Frame):
         self.recent_menu = wx.Menu()
         self.get_recent_session_menu()
         session_menu.Append(-1, 'Recent Session Files',  self.recent_menu)
-
 
         MenuItem(self, session_menu, "&Auto-Save Larch Session",
                  f"Save Session now",  self.autosave_session)
@@ -840,7 +840,6 @@ class LarixFrame(wx.Frame):
         MenuItem(self, xasdata_menu, "Add and Subtract Spectra",
                  "Calculations of Spectra",  self.onSpectraCalc)
 
-
         self.menubar.Append(file_menu, "&File")
         self.menubar.Append(session_menu, "Sessions")
         self.menubar.Append(pref_menu, "Preferences")
@@ -909,7 +908,7 @@ class LarixFrame(wx.Frame):
             return
 
         deffile = f"{filenames[0]:s}_{len(filenames):d}.csv"
-        wcards  = 'CSV Files (*.csv)|*.csv|All files (*.*)|*.*'
+        wcards = 'CSV Files (*.csv)|*.csv|All files (*.*)|*.*'
 
         outfile = FileSave(self, 'Save Groups to CSV File',
                            default_file=deffile, wildcard=wcards)
@@ -932,7 +931,7 @@ class LarixFrame(wx.Frame):
             groups2csv(savegroups, outfile, x=res.xarray, y=res.yarray,
                     delim=res.delim, individual=res.individual)
             self.write_message(f"Exported CSV file {outfile:s}")
-        except:
+        except Exception:
             title = "Could not export CSV File"
             message = [f"Could not export CSV File {outfile}"]
             ExceptionPopup(self, title, message)
@@ -945,9 +944,9 @@ class LarixFrame(wx.Frame):
             groups.append(self.controller.file_groups[str(checked)])
 
         if len(groups) < 1:
-             Popup(self, "No files selected to export to Project",
+            Popup(self, "No files selected to export to Project",
                    "No files selected")
-             return
+            return
         prompt, prjfile = self.get_athena_project()
         self.save_athena_project(prjfile, groups)
 
@@ -1006,7 +1005,6 @@ class LarixFrame(wx.Frame):
         self.write_message("Saved project file %s" % (filename))
         self.last_athena_file = filename
 
-
     def onPreferences(self, evt=None):
         self.show_subframe('preferences', PreferencesFrame,
                            controller=self.controller)
@@ -1027,7 +1025,7 @@ class LarixFrame(wx.Frame):
 
         try:
             _session  = read_session(path)
-        except:
+        except Exception:
             title = "Invalid Path for Larch Session"
             message = [f"{path} is not a valid Larch Session File"]
             ExceptionPopup(self, title, message)
@@ -1048,7 +1046,6 @@ class LarixFrame(wx.Frame):
             return
         self.last_session_file = None
         self.onSaveSession()
-
 
     def onSaveSession(self, evt=None):
         groups = self.controller.filelist.GetItems()
@@ -1110,10 +1107,8 @@ before clearing"""
             self.controller.clear_session()
         dlg.Destroy()
 
-
     def onConfigDataProcessing(self, event=None):
         pass
-
 
     def onCopyGroup(self, event=None, journal=None):
         fname = self.current_filename
@@ -1168,7 +1163,6 @@ before clearing"""
             fname = all_names.pop(n)
             self.controller.filelist.refresh(all_names)
             self.RemoveFile(fname)
-
 
     def onRemoveGroups(self, event=None):
         groups = []
@@ -1364,7 +1358,7 @@ before clearing"""
             try:
                 self.subframes[name].Raise()
                 shown = True
-            except:
+            except Exception:
                 del self.subframes[name]
         if not shown:
             self.subframes[name] = frameclass(self, **opts)
@@ -1385,7 +1379,6 @@ before clearing"""
 
     def onLoadFitResult(self, event=None):
         pass
-
 
     def onReadDialog(self, event=None):
         dlg = wx.FileDialog(self, message="Read Data File",
@@ -1525,7 +1518,6 @@ before clearing"""
                     self.install_group(ngroup, dname, source=path, journal=njournal,
                                        plot='no')
 
-
         cur_panel.skip_plotting = False
 
         if gname is not None:
@@ -1634,7 +1626,6 @@ before clearing"""
                 a = float(getattr(abkg, 'fixstep', 0.0))
                 conf_xasnorm['auto_step'] = (a < 0.5)
 
-
             # bkg
             for attr in ('e0', 'rbkg'):
                 if hasattr(abkg, attr):
@@ -1647,11 +1638,10 @@ before clearing"""
                     val = getattr(abkg, alt)
                     try:
                         val = float(getattr(abkg, alt))
-                    except:
+                    except Exception:
                         if alt.startswith('clamp') and isinstance(val, str):
                             val = ATHENA_CLAMPNAMES.get(val.lower(), 0)
                     conf_exafs[attr] = val
-
 
             # fft
             for attr in ('kmin', 'kmax', 'dk', 'kwindow', 'kw'):
@@ -1753,6 +1743,7 @@ before clearing"""
         self.install_group(groupname, filename, source=path, journal=journal, plot='auto')
 
         dtype = getattr(config, 'datatype', 'xydata')
+
         def install_multichans(config):
             yplotline = None
             yarray = 'mu' if dtype == 'xas' else 'ydat'
@@ -1808,7 +1799,7 @@ before clearing"""
         if thisgroup.datatype == 'xas':
             try:
                 en = thisgroup.energy
-            except:
+            except Exception:
                 do_rebin = True
                 en = thisgroup.energy = thisgroup.xplot
             # test for rebinning:
@@ -1869,7 +1860,6 @@ before clearing"""
 
                 self.install_group(refgroup, reffile, source=path, journal=refjournal,
                                        plot='no')
-
 
         if gname is not None:
             self.ShowFile(groupname=gname, process=True, plot='yes')
@@ -1988,7 +1978,6 @@ before clearing"""
             self.write_message('Select Point Error')
         self.cursor_dat = {}
 
-
     def onSelPoint(self, evt=None, opt='__', relative_e0=True, callback=None,
                    win=None):
         """
@@ -2030,7 +2019,7 @@ before clearing"""
                     self.cursor_dat['callback'](**self.cursor_dat)
             else:
                 self.write_message('No Points selected from plot window!')
-        else: # "pin first" mode
+        else:  # "pin first" mode
             if len(cursor_hist) > 2:  # purge old cursor history
                 setattr(self.larch.symtable._plotter, curhist_name, cursor_hist[:2])
 
@@ -2058,6 +2047,7 @@ class LarixApp(LarchWxApp):
                                 check_version=self.check_version)
         self.SetTopWindow(self.frame)
         return True
+
 
 def larix(**kws):
     LarixApp(**kws)

--- a/larch/wxxas/xasgui.py
+++ b/larch/wxxas/xasgui.py
@@ -421,7 +421,6 @@ class LarixFrame(wx.Frame):
         iconfile = Path(icondir, ICON_FILE).as_posix()
         self.SetIcon(wx.Icon(iconfile, wx.BITMAP_TYPE_ICO))
 
-        savefile = Path(self.controller.autosave_session())
         self.last_autosave = 0
         self.last_save_message = ('Session has not been saved', '', '')
 
@@ -432,8 +431,7 @@ class LarixFrame(wx.Frame):
         self.cursor_dat = {}
 
         self.subframes = {}
-        title = f"Larix [{savefile.name}]"
-        self.SetTitle(title)
+        self.onSetTitle()
         self.SetSize(LARIX_SIZE)
         self.SetMinSize(LARIX_MINSIZE)
         self.SetFont(Font(FONTSIZE))
@@ -865,6 +863,13 @@ class LarixFrame(wx.Frame):
         self.SetMenuBar(self.menubar)
         self.Bind(wx.EVT_CLOSE,  self.onClose)
         self.Bind(wx.EVT_SYS_COLOUR_CHANGED, self.onSystemDarkMode)
+
+    def onSetTitle(self, savefile=None):
+        """set title of main window"""
+        if savefile is not None:
+            self.SetTitle(f"Larix [{Path(savefile).name}]")
+        else:
+            self.SetTitle(LARIX_TITLE)
 
     def onSystemDarkMode(self, event=None):
         """notify on light/dark mode change"""

--- a/larch/wxxas/xasgui.py
+++ b/larch/wxxas/xasgui.py
@@ -431,7 +431,7 @@ class LarixFrame(wx.Frame):
         self.cursor_dat = {}
 
         self.subframes = {}
-        self.onSetTitle()
+        self.SetTitle(LARIX_TITLE)
         self.SetSize(LARIX_SIZE)
         self.SetMinSize(LARIX_MINSIZE)
         self.SetFont(Font(FONTSIZE))
@@ -1086,7 +1086,7 @@ class LarixFrame(wx.Frame):
         self.last_save_message = ("Session last saved", f"'{fname}'", f"{stime}")
         self.write_message(f"Saved session to '{fname}' at {stime}")
         self.last_session_file = self.last_session_read = fname
-        self.onSetTitle()
+        self.onSetTitle(Path(fname).name)
 
     def onClearSession(self, evt=None):
         conf = self.controller.get_config('autosave',

--- a/larch/wxxas/xasgui.py
+++ b/larch/wxxas/xasgui.py
@@ -74,6 +74,8 @@ from larch.io import (read_ascii, read_xdi, read_gsexdi, gsescan_group,
                       AthenaProject, make_hashkey, is_specfile, open_specfile)
 from larch.io.xas_data_source import open_xas_source
 
+from .larix_app import LARIX_TITLE
+
 # FNB_STYLE = flat_nb.FNB_NO_X_BUTTON
 FNB_STYLE = flat_nb.FNB_X_ON_TAB
 FNB_STYLE |= flat_nb.FNB_SMART_TABS|flat_nb.FNB_NO_NAV_BUTTONS
@@ -89,8 +91,6 @@ PLOTWIN_SIZE = (550, 550)
 
 QUIT_MESSAGE = '''Really Quit? You may want to save your project before quitting.
  This is not done automatically!'''
-
-LARIX_TITLE = "Larix: XAS Visualization and Analysis"
 
 def assign_gsescan_groups(group):
     labels = group.array_labels


### PR DESCRIPTION
@newville I propose to show the file name of the current session file in the Larix main window. This is very useful when working with multiple Larix instances at a time.

This is the first time that I propose a change in the Wx GUI, so please cross-check that I have not introduced bugs. One that seems to be appearing is the fact that now when I open a file, it does not remember my last path, but I am not sure of it neither.

I have also forced closing the read session dialog after clicking on "import selected data" (it was keeping it open and one has to manually close this window).

One thing that I have not managed doing, but it would be nice to do, is to also change the plot window main title to be more explicit. In fact, when opening multiple Larix instances, one gets all the plot windows with the same title and it is impossible to know what is what.

I have also done some minor PEP8-related formatting and fixes (correct spacing between `def` and `except Exception:` syntax).

Please, feel free to comment/fix/modify as you prefer