### PR TITLE
prefix used to define form instead of fcn

### DIFF
--- a/larch/wxxas/prepeak_panel.py
+++ b/larch/wxxas/prepeak_panel.py
@@ -1189,7 +1189,7 @@ write_ascii('{savefile:s}', {gname:s}.energy, {gname:s}.norm, {gname:s}.prepeaks
         title = prefix[:-1]
         mclass_kws = {'prefix': prefix}
         if 'step' in mod_abbrev:
-            form = mod_abbrev.replace('_step', '').strip()
+            form = prefix.split('_')[0]
             for sname, fullname in (('lin', 'linear'), ('atan', 'arctan'),
                                     ('err', 'erf'), ('logi', 'logistic')):
                 if form.startswith(sname):


### PR DESCRIPTION
Currently, saved arctan step functions are added as linear steps when loading fits from history. This is because the model function name is passed to add_model on line 1465 (https://github.com/xraypy/xraylarch/blob/9e8e5fbe07973c015aa9c9384c925457a9e151fd/larch/wxxas/prepeak_panel.py#L1465), and all step functions map to the the same name (https://github.com/xraypy/xraylarch/blob/9e8e5fbe07973c015aa9c9384c925457a9e151fd/larch/wxxas/prepeak_panel.py#L76). 

It seems like the easiest fix is to use the prefix to get the form when adding the step functions. 