### PR TITLE
Update FEFF header parsing to avoid false matches in author and title lines

### DIFF
--- a/larch/xafs/feffdat.py
+++ b/larch/xafs/feffdat.py
@@ -14,6 +14,7 @@ creates a group that contains the chi(k) for the sum of paths.
 """
 from pathlib import Path
 import numpy as np
+import re
 from copy import deepcopy
 from scipy.interpolate import UnivariateSpline
 from lmfit import Parameters, Parameter
@@ -193,24 +194,23 @@ class FeffDatFile(Group):
                 mode = 'path'
                 continue
             #
-            if (mode == 'header' and
-                line.startswith('Abs') or line.startswith('Pot')):
+            if mode == 'header' and (re.match(r'^Abs\b', line) or re.match(r'^Pot\s+\d+\b', line)) and re.search(r'\bZ\s*=', line):
                 words = line.replace('=', ' ').split()
                 ipot, z, rmt, rnm = (0, 0, 0, 0)
                 words.pop(0)
-                if line.startswith('Pot'):
+                if re.match(r'^Pot\s+\d+\b', line):
                     ipot = int(words.pop(0))
                 iz = int(words[1])
                 rmt = float(words[3])
                 rnm = float(words[5])
-                if line.startswith('Abs'):
+                if re.match(r'^Abs\b', line):
                     self.shell = words[6]
                 self.potentials.append((ipot, iz, rmt, rnm))
-            elif mode == 'header' and line.startswith('Gam_ch'):
+            elif mode == 'header' and re.match(r'^Gam_ch\s*=', line):
                 words  = line.replace('=', ' ').split(None, 2)
                 self.gam_ch = float(words[1])
                 self.exch   = words[2]
-            elif mode == 'header' and line.startswith('Mu='):
+            elif mode == 'header' and re.match(r'^Mu\s*=', line):
                 words  = line.replace('=', ' ').replace('eV', ' ').split()
                 self.vmu = float(words[1])
                 self.vfermi = ktoe(float(words[3]))


### PR DESCRIPTION
**Problem**
The FEFF .dat parser `feffpath` in `larch.xafs.feffdat` identifies header lines using broad `startswith()` checks (e.g. `Mu`, `Gam_ch`, `Abs`, `Pot`). This can lead to false positives when free-text header lines (such as author names or titles) begin with similar prefixes (e.g. "Muller, Olaf"), causing parsing errors during numeric conversion.

**Solution**
- Replacing `startswith()` checks with explicit regular-expression matches anchored at the start of the line (`re.match`) for header keywords: `Abs`, `Pot <index>`, `Gam_ch`, and `Mu`.
- Requiring structural markers (e.g. `Z=`) where appropriate to distinguish FEFF potential definitions from free text.

**Test**
Verified using FEFF6L input file generated by Demeter 0.9.26 containing an author line beginning with "Muller", which previously triggered a parsing failure. With this change, `feffpath()` parses the file correctly.

A minimal example and test script are attached for reference.
```python
import larch
from larch.xafs import feffpath
from larch.xafs.feffrunner import feff6l
feff6l(folder='./example', feffinp="feff.inp", verbose=True)
feffpath('./example/feff0001.dat')
```
[example.zip](https://github.com/user-attachments/files/24825003/example.zip)