### PR TITLE
Fixed inverted fpp in diffkk

### DIFF
--- a/larch/xafs/diffkk.py
+++ b/larch/xafs/diffkk.py
@@ -263,7 +263,7 @@ class diffKKGroup(Group):
         ## interpolate matched data onto an even grid with an even number of elements (about 1 eV)
         npts = int(self.energy[-1] - self.energy[0]) + (int(self.energy[-1] - self.energy[0])%2)
         self.grid = np.linspace(self.energy[0], self.energy[-1], npts)
-        fpp = interp(self.energy, self.f2-self.fpp, self.grid, fill_value=0.0)
+        fpp = interp(self.energy, self.fpp-self.f2, self.grid, fill_value=0.0)
 
         ## do difference KK
         if repr(how).startswith('sca'):


### PR DESCRIPTION
diffkk was producing apparently incorrect f' spectra from XAFS inputs (Issue #625). I believe this was due to inversion of extracted f'' fine structure on this line. kkmclr gives output as expected with a positive edge jump in f'' input and a negative cusp in f'.