### PR TITLE
RIXS updates + fix sever bug with Jupyter and Wx matplotlib backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 #### xraylarch library
  - fix `larch.plot`/RIXS imports eagerly loading `larch.wxlib`, which forced
    IPython's "%gui wx" hook and could deadlock a Jupyter kernel
+ - RIXS: split `RixsData.reset()` into `reset_crop`/`reset_cuts`, fix
+   `norm()` to properly min-max normalize both RIXS planes, and add a
+   `tick_step` option to `plot_rixs`/`plot_rixs_cuts` for evenly spaced
+   energy ticks
+ - RIXS: add sample-name glob filter to `rixs_esrf_fame.search_samples`
 
 ## [2026.2.2 - 2026-06-17]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ The GitHub Release Notes will also be useful
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+#### xraylarch library
+ - fix `larch.plot`/RIXS imports eagerly loading `larch.wxlib`, which forced
+   IPython's "%gui wx" hook and could deadlock a Jupyter kernel
+
 ## [2026.2.2 - 2026-06-17]
 
 ### Larix

--- a/larch/io/rixs_esrf_fame.py
+++ b/larch/io/rixs_esrf_fame.py
@@ -22,7 +22,7 @@ from larch.utils.logging import getLogger
 
 _logger = getLogger("io_rixs_bm16")
 __author__ = "Mauro Rovezzi"
-__version__ = "25.1.2"  #: this is the local version for this module only
+__version__ = "25.1.3"  #: this is the local version for this module only
 
 
 def search_samples(

--- a/larch/io/rixs_esrf_fame.py
+++ b/larch/io/rixs_esrf_fame.py
@@ -28,6 +28,7 @@ __version__ = "25.1.2"  #: this is the local version for this module only
 def search_samples(
     datadir: Union[str, Path],
     ignore_names: list[str] = ["rack", "mount", "align", "bl_"],
+    grepstr: str = "*",
 ) -> list[Path]:
     samples = []
     if isinstance(datadir, str):
@@ -37,7 +38,7 @@ def search_samples(
         errmsg = f"Cannot access: {search_dir}"
         _logger.error(errmsg)
         return samples
-    fnames = sorted(search_dir.glob("*"), key=lambda x: x.stat().st_ctime)
+    fnames = sorted(search_dir.glob(grepstr), key=lambda x: x.stat().st_ctime)
     isamp = 0
     _logger.info("Samples:")
     for fname in fnames:

--- a/larch/io/rixsdata.py
+++ b/larch/io/rixsdata.py
@@ -253,15 +253,27 @@ class RixsData(object):
         self.rixs_map = _zzcrop
         self.rixs_et_map = _ezzcrop
         self.label = f"{self.name} [{self._crop_area}]"
+        self.norm()
+
+    def reset_crop(self, **grid_kws):
+        """resets the RIXS plane to the initial grid, undoing any crop"""
+        self._logger.info("resetting RIXS plane to initial grid (undo crop)")
+        self.grid_rixs_from_col(**grid_kws)
+        self.label = self.name
+        self._crop_area = None
+
+    def reset_cuts(self):
+        """resets the line cuts and color palette"""
+        self._logger.info("resetting line cuts")
+        self.line_cuts = {}
+        self._palette = None
+        self._palette = CycleColors()
 
     def reset(self, **grid_kws):
         """resets to initial data"""
         self._logger.info("resetting to initial data (grid RIXS plane and line cuts)")
-        self.grid_rixs_from_col(**grid_kws)
-        self.line_cuts = {}
-        self.label = self.name
-        self._palette = None
-        self._palette = CycleColors()
+        self.reset_crop(**grid_kws)
+        self.reset_cuts()
 
     def grid_rixs_from_col(self, ene_grid=None, grid_method=None):
         """Grid RIXS map from XYZ columns"""
@@ -354,11 +366,19 @@ class RixsData(object):
         self._logger.info(f"added RIXS {mode} cut: '{label}'")
 
     def norm(self):
-        """Simple map normalization to max-min"""
-        self.rixs_map = self.rixs_map / (
-            np.nanmax(self.rixs_map) - np.nanmin(self.rixs_map)
-        )
-        self._logger.info("rixs map normalized to max-min")
+        """Normalize the RIXS plane(s) between 0 and 1 (min/max normalization)
+
+        The min/max intensity of `rixs_map` and `rixs_et_map` (if present)
+        is rescaled so that the minimum value maps to 0 and the maximum
+        value maps to 1.
+        """
+        for attr in ("rixs_map", "rixs_et_map"):
+            zz = getattr(self, attr)
+            if zz is None:
+                continue
+            zzmin, zzmax = np.nanmin(zz), np.nanmax(zz)
+            setattr(self, attr, (zz - zzmin) / (zzmax - zzmin))
+        self._logger.info(f"{self.name} normalized between 0 and 1")
 
 
 if __name__ == "__main__":

--- a/larch/plot/plot_rixsdata.py
+++ b/larch/plot/plot_rixsdata.py
@@ -12,7 +12,7 @@ import matplotlib.pyplot as plt
 
 from matplotlib import gridspec
 from matplotlib import cm
-from matplotlib.ticker import MaxNLocator, AutoLocator
+from matplotlib.ticker import MaxNLocator, AutoLocator, MultipleLocator
 from sympy import EX
 
 from larch.utils.logging import getLogger
@@ -31,6 +31,7 @@ def plot_rixs(
     y_label=None,
     x_nticks=0,
     y_nticks=0,
+    tick_step=None,
     x_min=None,
     x_max=None,
     y_min=None,
@@ -66,6 +67,10 @@ def plot_rixs(
 
     cont_imshow : boolean, optional [True]
         use plt.imshow instead of plt.contourf
+
+    tick_step : float, optional [None]
+        energy step (eV) between major XY ticks; minor ticks are
+        placed at half this step. Overrides x_nticks/y_nticks when set.
 
     """
     if not "RixsData" in str(type(rd)):
@@ -153,14 +158,22 @@ def plot_rixs(
         cont = plane.contour(
             x, y, zz, levels, colors="k", linewidths=cont_lwidths
         )
-    if x_nticks:
-        plane.xaxis.set_major_locator(MaxNLocator(int(x_nticks)))
+    if tick_step:
+        plane.xaxis.set_major_locator(MultipleLocator(tick_step))
+        plane.xaxis.set_minor_locator(MultipleLocator(tick_step / 2))
+        plane.yaxis.set_major_locator(MultipleLocator(tick_step))
+        plane.yaxis.set_minor_locator(MultipleLocator(tick_step / 2))
     else:
-        plane.xaxis.set_major_locator(AutoLocator())
-    if y_nticks:
-        plane.yaxis.set_major_locator(MaxNLocator(int(y_nticks)))
-    else:
-        plane.yaxis.set_major_locator(AutoLocator())
+        if x_nticks:
+            plane.xaxis.set_major_locator(MaxNLocator(int(x_nticks)))
+        else:
+            plane.xaxis.set_major_locator(AutoLocator())
+        if y_nticks:
+            plane.yaxis.set_major_locator(MaxNLocator(int(y_nticks)))
+        else:
+            plane.yaxis.set_major_locator(AutoLocator())
+
+    plt.setp(plane.get_xticklabels(), rotation=45, ha="right")
 
     # colorbar
     if cbar_show:

--- a/larch/plot/plot_rixsdata.py
+++ b/larch/plot/plot_rixsdata.py
@@ -173,7 +173,7 @@ def plot_rixs(
         else:
             plane.yaxis.set_major_locator(AutoLocator())
 
-    plt.setp(plane.get_xticklabels(), rotation=45, ha="right")
+    plt.setp(plane.get_xticklabels(), rotation=45, ha="right", rotation_mode="anchor")
 
     # colorbar
     if cbar_show:
@@ -195,8 +195,20 @@ def plot_rixs(
     return fig
 
 
-def plot_rixs_cuts(rd, et=True, fig_name="plot_rixs_cuts", fig_size=(8, 10), fig_dpi=75):
-    """plot RIXS line cuts"""
+def plot_rixs_cuts(
+    rd, et=True, fig_name="plot_rixs_cuts", fig_size=(8, 10), fig_dpi=75, tick_step=None
+):
+    """plot RIXS line cuts
+
+    Parameters
+    ----------
+
+    tick_step : float, optional [None]
+        energy step (eV) between major ticks on the energy axis (x);
+        minor ticks are placed at half this step. Does not affect the
+        intensity axis (y).
+
+    """
     assert len(rd.line_cuts.keys()) >= 1, "no line cuts are present"
     plt.close(fig_name)
     fig, axs = plt.subplots(nrows=3, num=fig_name, figsize=fig_size, dpi=fig_dpi)
@@ -234,6 +246,10 @@ def plot_rixs_cuts(rd, et=True, fig_name="plot_rixs_cuts", fig_size=(8, 10), fig
         ax.set_xlabel(x_label)
         ax.set_ylabel(y_label)
         ax.plot(x, y, label=label, color=color)
+        if tick_step:
+            ax.xaxis.set_major_locator(MultipleLocator(tick_step))
+            ax.xaxis.set_minor_locator(MultipleLocator(tick_step / 2))
+        plt.setp(ax.get_xticklabels(), rotation=45, ha="right", rotation_mode="anchor")
         ax.legend()
     fig.tight_layout()
     return fig

--- a/larch/plot/plot_rixsdata.py
+++ b/larch/plot/plot_rixsdata.py
@@ -151,7 +151,7 @@ def plot_rixs(
 
     if "line" in cont_type.lower():
         cont = plane.contour(
-            x, y, zz, levels, colors="k", hold="on", linewidths=cont_lwidths
+            x, y, zz, levels, colors="k", linewidths=cont_lwidths
         )
     if x_nticks:
         plane.xaxis.set_major_locator(MaxNLocator(int(x_nticks)))

--- a/larch/plot/wxmplot_xafsplots.py
+++ b/larch/plot/wxmplot_xafsplots.py
@@ -33,19 +33,62 @@ try:
 except ImportError:
     HAS_WXPYTHON = False
 
-get_display = plot = oplot = fitplot = plot_marker = plot_axvline = None
-
 def get_zorders(*args):
     return [0]
 
 def get_markercolors(trace=1, **kws):
     return '#AA0000', '#99887780'
 
+get_display = plot = oplot = fitplot = plot_marker = plot_axvline = imshow = None
+
+_wx_plotter_funcs = {}
+
+def _load_wx_plotter_funcs():
+    """import larch.wxlib.plotter lazily: it pulls in the full wx GUI
+    machinery (and wxmplot's IPython 'gui wx' event-loop hook), which
+    should only happen once a wx display is actually needed, not merely
+    because this module got imported.
+    """
+    if not _wx_plotter_funcs:
+        from larch.wxlib.plotter import (get_display, plot, oplot,
+                                         fitplot, plot_marker,
+                                         plot_axvline, imshow,
+                                         get_zorders, get_markercolors)
+        _wx_plotter_funcs.update(get_display=get_display, plot=plot,
+                                  oplot=oplot, fitplot=fitplot,
+                                  plot_marker=plot_marker,
+                                  plot_axvline=plot_axvline, imshow=imshow,
+                                  get_zorders=get_zorders,
+                                  get_markercolors=get_markercolors)
+    return _wx_plotter_funcs
+
 if HAS_WXPYTHON:
-    from larch.wxlib.plotter import (get_display, plot, oplot,
-                                     fitplot, plot_marker,
-                                     plot_axvline, imshow,
-                                     get_zorders, get_markercolors)
+    def get_display(*args, **kws):
+        return _load_wx_plotter_funcs()['get_display'](*args, **kws)
+
+    def plot(*args, **kws):
+        return _load_wx_plotter_funcs()['plot'](*args, **kws)
+
+    def oplot(*args, **kws):
+        return _load_wx_plotter_funcs()['oplot'](*args, **kws)
+
+    def fitplot(*args, **kws):
+        return _load_wx_plotter_funcs()['fitplot'](*args, **kws)
+
+    def plot_marker(*args, **kws):
+        return _load_wx_plotter_funcs()['plot_marker'](*args, **kws)
+
+    def plot_axvline(*args, **kws):
+        return _load_wx_plotter_funcs()['plot_axvline'](*args, **kws)
+
+    def imshow(*args, **kws):
+        return _load_wx_plotter_funcs()['imshow'](*args, **kws)
+
+    def get_zorders(*args, **kws):
+        return _load_wx_plotter_funcs()['get_zorders'](*args, **kws)
+
+    def get_markercolors(*args, **kws):
+        return _load_wx_plotter_funcs()['get_markercolors'](*args, **kws)
 
 def redraw(win=1, xmin=None, xmax=None, ymin=None, ymax=None,
            dymin=None, dymax=None,

--- a/larch/wxlib/plotter.py
+++ b/larch/wxlib/plotter.py
@@ -19,7 +19,6 @@ import wx
 from pathlib import Path
 from copy import deepcopy
 from wxmplot import PlotFrame, ImageFrame, StackedPlotFrame
-from wxmplot.interactive import get_wxapp
 from wxmplot.colors import rgb2hex, hex2rgb
 import larch
 from ..utils import mkdir
@@ -28,14 +27,6 @@ from ..larchlib import ensuremod
 from ..site_config import user_larchdir
 
 from .xrfdisplay import XRFDisplayFrame
-
-try:
-    from IPython import get_ipython
-    ipython = get_ipython()
-    if ipython is not None:
-        ipython.find_magic('gui')('wx')
-except Exception:
-    ipython = None
 
 mplconfdir = Path(user_larchdir, 'matplotlib').as_posix()
 mkdir(mplconfdir)
@@ -508,6 +499,10 @@ def get_display(win=1, _larch=None, wxparent=None, size=None, position=None,
 
     def _get_disp(symname, creator, win, ddict, wxparent,
                   size, position, _larch):
+        # import here, not at module level: this enables the IPython/Jupyter
+        # 'wx' event loop hook, which should only happen once a wx display is
+        # actually requested, not merely because this module got imported.
+        from wxmplot.interactive import get_wxapp
         wxapp = get_wxapp()
         display = None
         new_display = False

--- a/larch/wxlib/xrfdisplay.py
+++ b/larch/wxlib/xrfdisplay.py
@@ -1742,8 +1742,8 @@ class XRFDisplayFrame(wx.Frame):
         dlg.Destroy()
         return path
 
-from wxmplot.interactive import get_wxapp
 def larch_xrf_viewer():
+    from wxmplot.interactive import get_wxapp
     get_wxapp()
     xview = XRFDisplayFrame()
     xview.Show()

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -2,5 +2,6 @@ pytest test_athena_addgroup.py test_basic_processing.py \
  test_funccalls.py test_importlarch.py test_interpreter.py \
  test_jsonutils.py test_larch_interpreter.py test_larchexamples_basic.py \
  test_larchexamples_xafs.py test_larchexamples_xray.py \
- test_math_deglitch.py test_math_utils.py test_read_beamlinedata.py \
+ test_math_deglitch.py test_math_utils.py test_plot_rixsdata_import.py \
+ test_read_beamlinedata.py \
  test_read_xafsdata.py test_symbol_callbacks.py test_xas_data_source.py

--- a/tests/run_tests_with_wxgui.sh
+++ b/tests/run_tests_with_wxgui.sh
@@ -2,7 +2,8 @@ pytest test_athena_addgroup.py test_basic_processing.py \
  test_funccalls.py test_importlarch.py test_interpreter.py \
  test_jsonutils.py test_larch_interpreter.py test_larchexamples_basic.py \
  test_larchexamples_xafs.py test_larchexamples_xray.py \
- test_math_deglitch.py test_math_utils.py test_read_beamlinedata.py \
+ test_math_deglitch.py test_math_utils.py test_plot_rixsdata_import.py \
+ test_read_beamlinedata.py \
  test_read_xafsdata.py test_symbol_callbacks.py test_xas_data_source.py
 pytest test_wxlib_cif_browser.py
 pytest test_wxlib_structure2feff_browser.py

--- a/tests/test_plot_rixsdata_import.py
+++ b/tests/test_plot_rixsdata_import.py
@@ -1,0 +1,95 @@
+"""Regression tests for a bug where merely importing larch's non-wx,
+matplotlib-based RIXS plotting tools (e.g. in a Jupyter notebook) pulled in
+the entire wx GUI subsystem (larch.wxlib) as a side effect. That subsystem
+forces IPython's "%gui wx" event-loop hook at import time, which can
+deadlock a real Jupyter kernel (its asyncio/zmq event loop fights wx's).
+
+larch.plot is documented as "independent of the Wx GUI" and intended for
+standalone scripts and Jupyter notebooks, so importing it (or anything
+under it, like larch.plot.plot_rixsdata) must not import larch.wxlib.
+
+These run each check in a subprocess so that a clean sys.modules is
+guaranteed, regardless of import side effects from other tests in the
+same pytest session.
+"""
+import subprocess
+import sys
+
+import pytest
+
+pytest.importorskip("wx")  # the bug only exists when wxPython is installed
+
+
+def _run(code):
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True, text=True, timeout=60,
+    )
+    assert result.returncode == 0, (
+        f"subprocess failed:\nSTDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+    return result.stdout
+
+
+def test_import_plot_rixsdata_does_not_load_wxlib():
+    """importing the RIXS io/plot modules must not pull in larch.wxlib"""
+    code = (
+        "import sys\n"
+        "from larch.io.specfile_reader import DataSourceSpecH5\n"
+        "from larch.io.rixsdata import RixsData\n"
+        "from larch.plot.plot_rixsdata import plot_rixs, plot_rixs_cuts\n"
+        "from larch.io.rixs_esrf_fame import (get_rixs_bm16, save_rixs,\n"
+        "                                     search_samples, get_rixs_filenames)\n"
+        "assert 'larch.wxlib' not in sys.modules, 'larch.wxlib was imported eagerly'\n"
+        "print('OK')\n"
+    )
+    out = _run(code)
+    assert "OK" in out
+
+
+def test_import_larch_plot_does_not_load_wxlib():
+    """plain `import larch.plot` alone must not pull in larch.wxlib"""
+    code = (
+        "import sys\n"
+        "import larch.plot\n"
+        "assert 'larch.wxlib' not in sys.modules, 'larch.wxlib was imported eagerly'\n"
+        "print('OK')\n"
+    )
+    out = _run(code)
+    assert "OK" in out
+
+
+def test_import_plot_rixsdata_does_not_trigger_ipython_gui_hook():
+    """importing the RIXS io/plot modules must not force IPython's
+    '%gui wx' event-loop integration, even when running "inside" IPython
+    (simulated here via a fake get_ipython()). Installing that hook is
+    what deadlocked a real Jupyter kernel before this was fixed.
+    """
+    pytest.importorskip("IPython")
+    code = (
+        "import IPython\n"
+        "calls = []\n"
+        "class FakeMagic:\n"
+        "    def __call__(self, name):\n"
+        "        calls.append(name)\n"
+        "class FakeIPython:\n"
+        "    def find_magic(self, name):\n"
+        "        return FakeMagic()\n"
+        "IPython.get_ipython = lambda: FakeIPython()\n"
+        "\n"
+        "from larch.io.specfile_reader import DataSourceSpecH5\n"
+        "from larch.io.rixsdata import RixsData\n"
+        "from larch.plot.plot_rixsdata import plot_rixs, plot_rixs_cuts\n"
+        "from larch.io.rixs_esrf_fame import (get_rixs_bm16, save_rixs,\n"
+        "                                     search_samples, get_rixs_filenames)\n"
+        "assert calls == [], f'IPython gui hook was installed: {calls}'\n"
+        "print('OK')\n"
+    )
+    out = _run(code)
+    assert "OK" in out
+
+
+if __name__ == "__main__":
+    test_import_plot_rixsdata_does_not_load_wxlib()
+    test_import_larch_plot_does_not_load_wxlib()
+    test_import_plot_rixsdata_does_not_trigger_ipython_gui_hook()


### PR DESCRIPTION
@newville by doing some minor RIXS updates I found a severe bug crashing the Jupyter kernel when trying to plot RIXS planes. It was related to the fact that Ipython was setting Wx matplotlib backend. Now it is fixed. I have not tried myself the Wx plots from larch.plot, but the tests passes and I think it is safe to merge. If not, feel free to modify.